### PR TITLE
WIP: add embedded mkv subtitles

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "languagedetect": "^1.1.1",
     "location-history": "^1.0.0",
     "material-ui": "^0.15.4",
+    "matroska-subtitles": "^2.0.0",
     "musicmetadata": "^2.0.2",
     "network-address": "^1.1.0",
     "parse-torrent": "^5.7.3",


### PR DESCRIPTION
This PR should provide basic support for loading embedded mkv subtitles.
- The subtitles will only be loaded if the file is 100% downloaded.
- The subtitle language is determined by the `languagedetect` module and does not use mkv metadata.

Currently the code is overly complicated, because the embedded subtitles are loaded in a different way than subtitle files. `languagedetect` has not worked very well for me so maybe it's better to use the mkv metadata.

Also I wonder how often people actually uses mkv's with embedded subtitles that are also playable by WebTorrent Desktop?
