### PR TITLE
Add StartupWMClass on Linux desktop file

### DIFF
--- a/static/linux/share/applications/webtorrent-desktop.desktop
+++ b/static/linux/share/applications/webtorrent-desktop.desktop
@@ -12,6 +12,7 @@ Path=/opt/webtorrent-desktop
 Exec=/opt/webtorrent-desktop/WebTorrent %U
 TryExec=/opt/webtorrent-desktop/WebTorrent
 StartupNotify=false
+StartupWMClass=WebTorrent
 Categories=Network;FileTransfer;P2P;
 MimeType=application/x-bittorrent;x-scheme-handler/magnet;x-scheme-handler/stream-magnet;
 


### PR DESCRIPTION
StartupWMClass is used to identify the opened applications under Linux with their desktop files, which means using the right icon and so on... more information can be found here https://standards.freedesktop.org/desktop-entry-spec/latest/ar01s05.html

The value assigned on  StartupWMClass can be easily found using `xprop WM_CLASS` and click other application you would like to get the WM_CLASS.


What does this affect? Nothing at all, The only difference is that if an icon theme includes an icon for WebTorrent it will be used instead of using the default one. Also, the default one will look blurry on some Desktop environments. And the user won't be able to get to use the actions defined in the desktop file while running the application if it's not correctly identified. This is mostly needed for non-native applications

Without a WM_CLASS:
![screenshot from 2017-02-16 18-53-18](https://cloud.githubusercontent.com/assets/7660997/23033647/39bbff0a-f479-11e6-928a-6ce5061651fc.png)


With a WM_CLASS: 
![screenshot from 2017-02-16 18-55-01](https://cloud.githubusercontent.com/assets/7660997/23033702/76e32af2-f479-11e6-9746-a7c01888a2ae.png)

