### PR TITLE
Disable notifications

### DIFF
--- a/src/renderer/controllers/torrent-controller.js
+++ b/src/renderer/controllers/torrent-controller.js
@@ -92,7 +92,12 @@ module.exports = class TorrentController {
       if (!this.state.window.isFocused) {
         this.state.dock.badge += 1
       }
-      showDoneNotification(torrentSummary)
+
+      // Avoid displaying notification if notifications are disabled.
+      if (!this.state.saved.prefs.disableNotifications) {
+        showDoneNotification(torrentSummary)
+      }
+
       ipcRenderer.send('downloadFinished', getTorrentPath(torrentSummary))
     }
 

--- a/src/renderer/pages/preferences-page.js
+++ b/src/renderer/pages/preferences-page.js
@@ -25,6 +25,9 @@ class PreferencesPage extends React.Component {
 
     this.handleStartupChange =
       this.handleStartupChange.bind(this)
+
+    this.handleDisableNotifications =
+      this.handleDisableNotifications.bind(this)
   }
 
   downloadPathSelector () {
@@ -110,8 +113,25 @@ class PreferencesPage extends React.Component {
     )
   }
 
+  setNotifications () {
+    return (
+      <Preference>
+        <Checkbox
+            className='control'
+            checked={this.props.state.unsaved.prefs.disableNotifications}
+            label={"Disable notifications."}
+            onCheck={this.handleDisableNotifications}
+          />
+      </Preference>
+    )
+  }
+
   handleStartupChange (e, isChecked) {
     dispatch('updatePreferences', 'startup', isChecked)
+  }
+
+  handleDisableNotifications (e, isChecked) {
+    dispatch('updatePreferences', 'disableNotifications', isChecked)
   }
 
   setStartupSection () {
@@ -154,6 +174,9 @@ class PreferencesPage extends React.Component {
         </PreferencesSection>
         <PreferencesSection title='Default torrent app'>
           {this.setDefaultAppButton()}
+        </PreferencesSection>
+        <PreferencesSection title='Notifications'>
+          {this.setNotifications()}
         </PreferencesSection>
         {this.setStartupSection()}
       </div>

--- a/src/renderer/pages/preferences-page.js
+++ b/src/renderer/pages/preferences-page.js
@@ -117,11 +117,11 @@ class PreferencesPage extends React.Component {
     return (
       <Preference>
         <Checkbox
-            className='control'
-            checked={this.props.state.unsaved.prefs.disableNotifications}
-            label={"Disable notifications."}
-            onCheck={this.handleDisableNotifications}
-          />
+          className='control'
+          checked={this.props.state.unsaved.prefs.disableNotifications}
+          label={'Disable notifications.'}
+          onCheck={this.handleDisableNotifications}
+        />
       </Preference>
     )
   }


### PR DESCRIPTION
Added notifications section to preferences; added ability to disable notifications, when enabled no notification is shown when a torrent finishes downloading.
This is a response to this request #1130 .

If we plan to add more notifications maybe we can add a notifications controller and then handle this preference just there.

Cheers!