### PR TITLE
Watch folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "auto-launch": "^4.0.1",
     "bitfield": "^1.0.2",
     "capture-frame": "^1.0.0",
+    "chokidar": "^1.6.1",
     "chromecasts": "^1.8.0",
     "cp-file": "^4.0.1",
     "create-torrent": "^3.24.5",

--- a/src/main/folder-watcher.js
+++ b/src/main/folder-watcher.js
@@ -5,7 +5,7 @@ class FolderWatcher {
   constructor ({window, state}) {
     this.window = window
     this.state = state
-    this.torrentsFolderPath
+    this.torrentsFolderPath = null
     this.watching = false
   }
 

--- a/src/main/folder-watcher.js
+++ b/src/main/folder-watcher.js
@@ -6,9 +6,19 @@ class FolderWatcher {
     this.window = window
     this.state = state
     this.torrentsFolderPath
+    this.watching = false
   }
 
-  init () {
+  isEnabled () {
+    return this.state.saved.prefs.autoAddTorrents
+  }
+
+  start () {
+    log('--- FOLDER WATCHER --> START')
+    // Stop watching previous folder before
+    // start watching a new one.
+    if (this.watching) this.stop()
+
     const torrentsFolderPath = this.state.saved.prefs.torrentsFolderPath
     this.torrentsFolderPath = torrentsFolderPath
     if (!torrentsFolderPath) return
@@ -23,30 +33,15 @@ class FolderWatcher {
         log('-- torrent added: ', path)
         this.window.dispatch('addTorrent', path)
       })
-  }
 
-  start (torrentsFolderPath) {
-    // Stop watching previous folder before
-    // start watching a new one.
-    if (this.torrentsFolderPath) {
-      this.stop()
-    }
-
-    const glob = `${torrentsFolderPath}/**/*.torrent`
-    log('Folder Watcher: watching: ', glob)
-
-    const options = {ignoreInitial: true}
-    this.watcher = chokidar.watch(glob, options)
-    this.watcher
-      .on('add', (path) => {
-        log('-- torrent added: ', path)
-        this.window.dispatch('addTorrent', path)
-      })
+    this.watching = true
   }
 
   stop () {
-    if (!this.watcher) return
+    log('--- FOLDER WATCHER --> STOP')
+    if (!this.watching) return
     this.watcher.close()
+    this.watching = false
   }
 }
 

--- a/src/main/folder-watcher.js
+++ b/src/main/folder-watcher.js
@@ -1,4 +1,3 @@
-const ipc = require('electron').ipcMain
 const chokidar = require('chokidar')
 const log = require('./log')
 

--- a/src/main/folder-watcher.js
+++ b/src/main/folder-watcher.js
@@ -50,5 +50,4 @@ class FolderWatcher {
   }
 }
 
-
 module.exports = FolderWatcher

--- a/src/main/folder-watcher.js
+++ b/src/main/folder-watcher.js
@@ -1,3 +1,4 @@
+const ipc = require('electron').ipcMain
 const chokidar = require('chokidar')
 const log = require('./log')
 
@@ -14,7 +15,6 @@ class FolderWatcher {
   }
 
   start () {
-    log('--- FOLDER WATCHER --> START')
     // Stop watching previous folder before
     // start watching a new one.
     if (this.watching) this.stop()
@@ -30,7 +30,7 @@ class FolderWatcher {
     this.watcher = chokidar.watch(glob, options)
     this.watcher
       .on('add', (path) => {
-        log('-- torrent added: ', path)
+        log('Folder Watcher: added torrent: ', path)
         this.window.dispatch('addTorrent', path)
       })
 
@@ -38,7 +38,7 @@ class FolderWatcher {
   }
 
   stop () {
-    log('--- FOLDER WATCHER --> STOP')
+    log('Folder Watcher: stop.')
     if (!this.watching) return
     this.watcher.close()
     this.watching = false

--- a/src/main/folder-watcher.js
+++ b/src/main/folder-watcher.js
@@ -1,0 +1,54 @@
+const chokidar = require('chokidar')
+const log = require('./log')
+
+class FolderWatcher {
+  constructor ({window, state}) {
+    this.window = window
+    this.state = state
+    this.torrentsFolderPath
+  }
+
+  init () {
+    const torrentsFolderPath = this.state.saved.prefs.torrentsFolderPath
+    this.torrentsFolderPath = torrentsFolderPath
+    if (!torrentsFolderPath) return
+
+    const glob = `${torrentsFolderPath}/**/*.torrent`
+    log('Folder Watcher: watching: ', glob)
+
+    const options = {ignoreInitial: true}
+    this.watcher = chokidar.watch(glob, options)
+    this.watcher
+      .on('add', (path) => {
+        log('-- torrent added: ', path)
+        this.window.dispatch('addTorrent', path)
+      })
+  }
+
+  start (torrentsFolderPath) {
+    // Stop watching previous folder before
+    // start watching a new one.
+    if (this.torrentsFolderPath) {
+      this.stop()
+    }
+
+    const glob = `${torrentsFolderPath}/**/*.torrent`
+    log('Folder Watcher: watching: ', glob)
+
+    const options = {ignoreInitial: true}
+    this.watcher = chokidar.watch(glob, options)
+    this.watcher
+      .on('add', (path) => {
+        log('-- torrent added: ', path)
+        this.window.dispatch('addTorrent', path)
+      })
+  }
+
+  stop () {
+    if (!this.watcher) return
+    this.watcher.close()
+  }
+}
+
+
+module.exports = FolderWatcher

--- a/src/main/folder-watcher.js
+++ b/src/main/folder-watcher.js
@@ -25,7 +25,10 @@ class FolderWatcher {
     const glob = `${torrentsFolderPath}/**/*.torrent`
     log('Folder Watcher: watching: ', glob)
 
-    const options = {ignoreInitial: true}
+    const options = {
+      ignoreInitial: true,
+      awaitWriteFinish: true
+    }
     this.watcher = chokidar.watch(glob, options)
     this.watcher
       .on('add', (path) => {

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -72,13 +72,16 @@ function init () {
     if (err) throw err
 
     isReady = true
+    const state = results.state
 
-    windows.main.init(results.state, {hidden: hidden})
+    windows.main.init(state, {hidden: hidden})
     windows.webtorrent.init()
     menu.init()
 
     // To keep app startup fast, some code is delayed.
-    setTimeout(delayedInit, config.DELAYED_INIT)
+    setTimeout(() => {
+      delayedInit(state)
+    }, config.DELAYED_INIT)
 
     // Report uncaught exceptions
     process.on('uncaughtException', (err) => {
@@ -121,16 +124,19 @@ function init () {
   })
 }
 
-function delayedInit () {
+function delayedInit (state) {
   if (app.isQuitting) return
 
   const announcement = require('./announcement')
   const dock = require('./dock')
   const updater = require('./updater')
+  const FolderWatcher = require('./folder-watcher')
+  const folderWatcher = new FolderWatcher({window: windows.main, state})
 
   announcement.init()
   dock.init()
   updater.init()
+  folderWatcher.init()
 
   if (process.platform === 'win32') {
     const userTasks = require('./user-tasks')

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -136,7 +136,11 @@ function delayedInit (state) {
   announcement.init()
   dock.init()
   updater.init()
-  folderWatcher.init()
+
+  ipc.setModule('folderWatcher', folderWatcher)
+  if (folderWatcher.isEnabled()) {
+    folderWatcher.start()
+  }
 
   if (process.platform === 'win32') {
     const userTasks = require('./user-tasks')

--- a/src/main/ipc.js
+++ b/src/main/ipc.js
@@ -1,5 +1,6 @@
 module.exports = {
-  init
+  init,
+  setModule
 }
 
 const electron = require('electron')
@@ -12,6 +13,14 @@ const windows = require('./windows')
 
 // Messages from the main process, to be sent once the WebTorrent process starts
 const messageQueueMainToWebTorrent = []
+
+// Will hold modules injected from the app that will be used on fired
+// IPC events.
+const modules = {}
+
+function setModule (name, module) {
+  modules[name] = module
+}
 
 function init () {
   const ipc = electron.ipcMain
@@ -104,6 +113,16 @@ function init () {
 
     powerSaveBlocker.disable()
     thumbar.onPlayerPause()
+  })
+
+  ipc.on('startFolderWatcher', function () {
+    log('--- Torrent Watcher started')
+    modules['folderWatcher'].start()
+  })
+
+  ipc.on('stopFolderWatcher', function () {
+    log('--- Torrent Watcher stop')
+    modules['folderWatcher'].stop()
   })
 
   /**

--- a/src/main/ipc.js
+++ b/src/main/ipc.js
@@ -67,7 +67,7 @@ function init () {
   })
 
   /**
-   * Events
+   * Player Events
    */
 
   ipc.on('onPlayerOpen', function () {
@@ -115,13 +115,25 @@ function init () {
     thumbar.onPlayerPause()
   })
 
+  /**
+   * Folder Watcher Events
+   */
+
   ipc.on('startFolderWatcher', function () {
-    log('--- Torrent Watcher started')
+    if (!modules['folderWatcher']) {
+      log('IPC ERR: folderWatcher module is not defined.')
+      return
+    }
+
     modules['folderWatcher'].start()
   })
 
   ipc.on('stopFolderWatcher', function () {
-    log('--- Torrent Watcher stop')
+    if (!modules['folderWatcher']) {
+      log('IPC ERR: folderWatcher module is not defined.')
+      return
+    }
+
     modules['folderWatcher'].stop()
   })
 

--- a/src/renderer/controllers/folder-watcher-controller.js
+++ b/src/renderer/controllers/folder-watcher-controller.js
@@ -1,0 +1,13 @@
+const {ipcRenderer} = require('electron')
+
+module.exports = class FolderWatcherController {
+  start () {
+    console.log('-- IPC: start folder watcher')
+    ipcRenderer.send('startFolderWatcher')
+  }
+
+  stop () {
+    console.log('-- IPC: stop folder watcher')
+    ipcRenderer.send('stopFolderWatcher')
+  }
+}

--- a/src/renderer/lib/state.js
+++ b/src/renderer/lib/state.js
@@ -121,7 +121,9 @@ function setupStateSaved (cb) {
       isFileHandler: false,
       openExternalPlayer: false,
       externalPlayerPath: null,
-      startup: false
+      startup: false,
+      autoAddTorrents: false,
+      torrentsFolderPath: ''
     },
     torrents: config.DEFAULT_TORRENTS.map(createTorrentObject),
     torrentsToResume: [],

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -111,6 +111,10 @@ function onState (err, _state) {
     update: createGetter(() => {
       const UpdateController = require('./controllers/update-controller')
       return new UpdateController(state)
+    }),
+    folderWatcher: createGetter(() => {
+      const FolderWatcherController = require('./controllers/folder-watcher-controller')
+      return new FolderWatcherController()
     })
   }
 
@@ -296,6 +300,8 @@ const dispatchHandlers = {
   'preferences': () => controllers.prefs().show(),
   'updatePreferences': (key, value) => controllers.prefs().update(key, value),
   'checkDownloadPath': checkDownloadPath,
+  'startFolderWatcher': () => controllers.folderWatcher().start(),
+  'stopFolderWatcher': () => controllers.folderWatcher().stop(),
 
   // Update (check for new versions on Linux, where there's no auto updater)
   'updateAvailable': (version) => controllers.update().updateAvailable(version),

--- a/src/renderer/pages/preferences-page.js
+++ b/src/renderer/pages/preferences-page.js
@@ -108,6 +108,56 @@ class PreferencesPage extends React.Component {
     dispatch('updatePreferences', 'externalPlayerPath', filePath)
   }
 
+  autoAddTorrentsCheckbox () {
+    return (
+      <Preference>
+        <Checkbox
+          className='control'
+          checked={this.props.state.unsaved.prefs.autoAddTorrents}
+          label={'Enable'}
+          onCheck={(e, value) => {this.handleAutoAddTorrentsChange(e, value)}}
+        />
+      </Preference>
+    )
+  }
+
+  handleAutoAddTorrentsChange (e, isChecked) {
+    const torrentsFolderPath = this.props.state.unsaved.prefs.torrentsFolderPath
+    if (isChecked && !torrentsFolderPath) {
+      alert('Select a torrents folder first.')
+      e.preventDefault()
+      return
+    }
+
+    dispatch('updatePreferences', 'autoAddTorrents', isChecked)
+  }
+
+  torrentsFolderPathSelector () {
+    const torrentsFolderPath = this.props.state.unsaved.prefs.torrentsFolderPath
+
+    const value = torrentsFolderPath || 'Path to be watched.'
+    const description = 'Torrent files saved to this folder will be automatically added to the list.'
+
+    return (
+      <Preference>
+        <p>{description}</p>
+        <PathSelector
+          dialog={{
+            title: 'Select torrents folder path',
+            properties: [ 'openDirectory' ]
+          }}
+          displayValue={value}
+          onChange={this.handletorrentsFolderPathChange}
+          title='Torrents folder'
+          value={torrentsFolderPath ? path.dirname(torrentsFolderPath) : null} />
+      </Preference>
+    )
+  }
+
+  handletorrentsFolderPathChange (filePath) {
+    dispatch('updatePreferences', 'torrentsFolderPath', filePath)
+  }
+
   setDefaultAppButton () {
     const isFileHandler = this.props.state.unsaved.prefs.isFileHandler
     if (isFileHandler) {
@@ -173,6 +223,10 @@ class PreferencesPage extends React.Component {
         </PreferencesSection>
         <PreferencesSection title='Default torrent app'>
           {this.setDefaultAppButton()}
+        </PreferencesSection>
+        <PreferencesSection title='Auto add torrents'>
+          {this.autoAddTorrentsCheckbox()}
+          {this.torrentsFolderPathSelector()}
         </PreferencesSection>
         {this.setStartupSection()}
       </div>

--- a/src/renderer/pages/preferences-page.js
+++ b/src/renderer/pages/preferences-page.js
@@ -130,6 +130,13 @@ class PreferencesPage extends React.Component {
     }
 
     dispatch('updatePreferences', 'autoAddTorrents', isChecked)
+
+    if (isChecked) {
+      dispatch('startFolderWatcher', null)
+      return
+    }
+
+    dispatch('stopFolderWatcher', null)
   }
 
   torrentsFolderPathSelector () {

--- a/src/renderer/pages/preferences-page.js
+++ b/src/renderer/pages/preferences-page.js
@@ -114,7 +114,7 @@ class PreferencesPage extends React.Component {
         <Checkbox
           className='control'
           checked={this.props.state.unsaved.prefs.autoAddTorrents}
-          label={'Enable'}
+          label={'Watch for new .torrent files and add them immediately'}
           onCheck={(e, value) => { this.handleAutoAddTorrentsChange(e, value) }}
         />
       </Preference>
@@ -142,20 +142,16 @@ class PreferencesPage extends React.Component {
   torrentsFolderPathSelector () {
     const torrentsFolderPath = this.props.state.unsaved.prefs.torrentsFolderPath
 
-    const value = torrentsFolderPath || 'Path to be watched.'
-    const description = 'Torrent files saved to this folder will be automatically added.'
-
     return (
       <Preference>
-        <p>{description}</p>
         <PathSelector
           dialog={{
-            title: 'Select torrents folder path',
+            title: 'Select folder to watch for new torrents',
             properties: [ 'openDirectory' ]
           }}
-          displayValue={value}
+          displayValue={torrentsFolderPath || ''}
           onChange={this.handletorrentsFolderPathChange}
-          title='Torrents folder'
+          title='Folder to watch'
           value={torrentsFolderPath ? path.dirname(torrentsFolderPath) : null} />
       </Preference>
     )
@@ -220,8 +216,10 @@ class PreferencesPage extends React.Component {
     }
     return (
       <div style={style}>
-        <PreferencesSection title='Downloads'>
+        <PreferencesSection title='Folders'>
           {this.downloadPathSelector()}
+          {this.autoAddTorrentsCheckbox()}
+          {this.torrentsFolderPathSelector()}
         </PreferencesSection>
         <PreferencesSection title='Playback'>
           {this.openExternalPlayerCheckbox()}
@@ -230,10 +228,6 @@ class PreferencesPage extends React.Component {
         </PreferencesSection>
         <PreferencesSection title='Default torrent app'>
           {this.setDefaultAppButton()}
-        </PreferencesSection>
-        <PreferencesSection title='Auto add torrents'>
-          {this.autoAddTorrentsCheckbox()}
-          {this.torrentsFolderPathSelector()}
         </PreferencesSection>
         {this.setStartupSection()}
       </div>

--- a/src/renderer/pages/preferences-page.js
+++ b/src/renderer/pages/preferences-page.js
@@ -115,7 +115,7 @@ class PreferencesPage extends React.Component {
           className='control'
           checked={this.props.state.unsaved.prefs.autoAddTorrents}
           label={'Enable'}
-          onCheck={(e, value) => {this.handleAutoAddTorrentsChange(e, value)}}
+          onCheck={(e, value) => { this.handleAutoAddTorrentsChange(e, value) }}
         />
       </Preference>
     )
@@ -124,7 +124,7 @@ class PreferencesPage extends React.Component {
   handleAutoAddTorrentsChange (e, isChecked) {
     const torrentsFolderPath = this.props.state.unsaved.prefs.torrentsFolderPath
     if (isChecked && !torrentsFolderPath) {
-      alert('Select a torrents folder first.')
+      alert('Select a torrents folder first.') // eslint-disable-line
       e.preventDefault()
       return
     }
@@ -136,7 +136,7 @@ class PreferencesPage extends React.Component {
     const torrentsFolderPath = this.props.state.unsaved.prefs.torrentsFolderPath
 
     const value = torrentsFolderPath || 'Path to be watched.'
-    const description = 'Torrent files saved to this folder will be automatically added to the list.'
+    const description = 'Torrent files saved to this folder will be automatically added.'
 
     return (
       <Preference>


### PR DESCRIPTION
In response to #1149, this feature adds a preference to watch a folder for new `.torrent` files.
When a torrent file is saved on the watched folder it is automatically added to WebTorrent Desktop.
The feature can be enabled / disabled from preferences.

![image](https://cloud.githubusercontent.com/assets/1118293/24302567/dd50ecb4-1091-11e7-9256-fbcff5659cc2.png)
