### PR TITLE
Add support for subtitles on Chromecast

### DIFF
--- a/src/renderer/webtorrent.js
+++ b/src/renderer/webtorrent.js
@@ -320,7 +320,8 @@ function startServerFromReadyTorrent (torrent, cb) {
     const info = {
       torrentKey: torrent.key,
       localURL: 'http://localhost' + urlSuffix,
-      networkURL: 'http://' + networkAddress() + urlSuffix
+      networkURL: 'http://' + networkAddress() + urlSuffix,
+      networkAddress: networkAddress()
     }
 
     ipc.send('wt-server-running', info)


### PR DESCRIPTION
Support subtitles on Chromecast by creating a new http server for selected subtitles before calling player.play()

Closes #530 