### PR TITLE
Use tabular nums and fixed width for no jitter on time

### DIFF
--- a/src/renderer/pages/player-page.js
+++ b/src/renderer/pages/player-page.js
@@ -652,9 +652,10 @@ function formatTime (time, total) {
   }
 
   let totalHours = Math.floor(total / 3600)
+  let totalMinutes = Math.floor(total % 3600 / 60)
   let hours = Math.floor(time / 3600)
   let minutes = Math.floor(time % 3600 / 60)
-  if (totalHours > 0) {
+  if (totalMinutes > 9) {
     minutes = zeroFill(2, minutes)
   }
   let seconds = zeroFill(2, Math.floor(time % 60))

--- a/src/renderer/pages/player-page.js
+++ b/src/renderer/pages/player-page.js
@@ -523,8 +523,8 @@ function renderPlayerControls (state) {
   ))
 
   // Show video playback progress
-  const currentTimeStr = formatTime(state.playing.currentTime)
-  const durationStr = formatTime(state.playing.duration)
+  const currentTimeStr = formatTime(state.playing.currentTime, state.playing.duration)
+  const durationStr = formatTime(state.playing.duration, state.playing.duration)
   elements.push((
     <span key='time' className='time float-left'>
       {currentTimeStr} / {durationStr}
@@ -646,17 +646,18 @@ function cssBackgroundImageDarkGradient () {
     'rgba(0,0,0,0.4) 0%, rgba(0,0,0,1) 100%)'
 }
 
-function formatTime (time) {
+function formatTime (time, total) {
   if (typeof time !== 'number' || Number.isNaN(time)) {
     return '0:00'
   }
 
+  let totalHours = Math.floor(total / 3600)
   let hours = Math.floor(time / 3600)
   let minutes = Math.floor(time % 3600 / 60)
-  if (hours > 0) {
+  if (totalHours > 0) {
     minutes = zeroFill(2, minutes)
   }
   let seconds = zeroFill(2, Math.floor(time % 60))
 
-  return (hours > 0 ? hours + ':' : '') + minutes + ':' + seconds
+  return (totalHours > 0 ? hours + ':' : '') + minutes + ':' + seconds
 }

--- a/static/main.css
+++ b/static/main.css
@@ -615,6 +615,7 @@ body.drag .app::after {
   font-size: 13px;
   margin: 9px 8px 8px 8px;
   opacity: 0.8;
+  font-variant-numeric: tabular-nums;
 }
 
 .player .controls .icon.closed-caption {


### PR DESCRIPTION
The width of the video time was making me uncomfortable 😅, so I fixed by having the numbers be tabular and formatting the time with consideration for the total time. 

I was unable to run the integration tests on my 2016 12" Macbook.

I guess using tabular nums could be applied a lot of other places in the app, such as download percentage, file sizes etc.

Before Image:

![Before](https://user-images.githubusercontent.com/416524/29785546-4dc09906-8c28-11e7-811b-62ec5cfbb064.gif)

After image (Added 1h to duration for test purpose):

![After](https://user-images.githubusercontent.com/416524/29785518-35f5d552-8c28-11e7-86d9-840b90ae6c1c.gif)

