### PR TITLE
Add .torrent to Github releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,8 @@
     "spectron": "^3.3.0",
     "standard": "*",
     "tape": "^4.6.0",
-    "walk-sync": "^0.3.1"
+    "walk-sync": "^0.3.1",
+    "webtorrentify-github-release": "^0.0.3"
   },
   "engines": {
     "node": ">=4.0.0"
@@ -98,7 +99,7 @@
   "scripts": {
     "build": "buble src --output build",
     "clean": "node ./bin/clean.js",
-    "gh-release": "gh-release",
+    "gh-release": "gh-release && webtorrentify-github-release",
     "open-config": "node ./bin/open-config.js",
     "package": "node ./bin/package.js",
     "prepublish": "npm run build",


### PR DESCRIPTION
This is a continuation of the ideas from https://github.com/webtorrent/webtorrent.io/pull/116. This PR shows one way we could start creating torrent files for WebTorrent Desktop releases so you could distribute WebTorrent Desktop via WebTorrent. It uses my new handy module, [`webtorrentify-github-release`](https://github.com/wmhilton/webtorrentify-github-release), which is designed to work with existing Github Releases, so you can try applying it ad-hoc before commiting the time to build it into the CI pipeline.

Even after the torrents are created though, we still need to solve the seeding and CORS obstacles. I would love to use the Github Releases as web seeds, but I'm not sure Github's URL architecture will allow for that.

My suggestion is you try running `webtorrentify-github-release` and examine/play with the resulting torrent file and figure out how to seed it. I am also looking for feedback as to the merits the approach, or even the merit of the overall goal and whether this is as awesome as I think.