### PR TITLE
Release media keys when opening external player

### DIFF
--- a/src/main/ipc.js
+++ b/src/main/ipc.js
@@ -173,9 +173,11 @@ function init () {
 
   ipc.on('openExternalPlayer', (e, ...args) => {
     const externalPlayer = require('./external-player')
+    const shortcuts = require('./shortcuts')
     const thumbar = require('./thumbar')
 
     menu.togglePlaybackControls(false)
+    shortcuts.disable()
     thumbar.disable()
     externalPlayer.spawn(...args)
   })


### PR DESCRIPTION
Until now, media keys didn't work when playing a file in VLC (at least on Linux), because they were already taken by WebTorrent. This PR fixes that.