### PR TITLE
"Error" text on missing Codec error changed to "Unable to Play"

### DIFF
--- a/src/renderer/pages/player-page.js
+++ b/src/renderer/pages/player-page.js
@@ -303,7 +303,7 @@ function renderCastScreen (state) {
     isCast = false
   } else if (state.playing.location === 'error') {
     castIcon = 'error_outline'
-    castType = 'Error'
+    castType = 'Unable to Play'
     isCast = false
   }
 


### PR DESCRIPTION
New users will usually leave a software when it _apparently_ fails to deliver what it promised. 
I was surprised myself when I got an error on my first try, but as the explorer that I am, I got through.

I recommended this software to two friends ( neither from the tech areas ), and both closed it after they saw the error message. I know it is a small sample, but I believe it represents the reason for a good amount of bounces in Webtorrent Desktop.

Most torrent users already have VLC or other good softwares, and wont event need to install them. Showing "Unable to Play" instead of "Error" makes this amazing functionality more new-user friendly.