### PR TITLE
Update 'chromecasts' dependency to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "bitfield": "^1.0.2",
     "capture-frame": "^1.0.0",
     "chokidar": "^1.6.1",
-    "chromecasts": "^1.8.0",
+    "chromecasts": "^1.9.1",
     "cp-file": "^4.0.1",
     "create-torrent": "^3.24.5",
     "debounce": "^1.0.0",


### PR DESCRIPTION
This should close:
- https://github.com/webtorrent/webtorrent-desktop/issues/1193
- https://github.com/webtorrent/webtorrent-desktop/issues/1202