### PR TITLE
Torrent List page: Add file name sorting

### DIFF
--- a/src/renderer/lib/playlist.js
+++ b/src/renderer/lib/playlist.js
@@ -72,7 +72,7 @@ function updateCache (state) {
 
 function findPreviousIndex (state) {
   const files = TorrentSummary.getByKey(state, state.playing.infoHash).files
-        .sort((a, b) => a.name.localeCompare(b.name))
+    .sort((a, b) => a.name.localeCompare(b.name))
   for (let i = state.playing.fileIndex - 1; i >= 0; i--) {
     if (TorrentPlayer.isPlayable(files[i])) return i
   }
@@ -81,7 +81,7 @@ function findPreviousIndex (state) {
 
 function findNextIndex (state) {
   const files = TorrentSummary.getByKey(state, state.playing.infoHash).files
-        .sort((a, b) => a.name.localeCompare(b.name))
+    .sort((a, b) => a.name.localeCompare(b.name))
   for (let i = state.playing.fileIndex + 1; i < files.length; i++) {
     if (TorrentPlayer.isPlayable(files[i])) return i
   }

--- a/src/renderer/lib/playlist.js
+++ b/src/renderer/lib/playlist.js
@@ -71,7 +71,8 @@ function updateCache (state) {
 }
 
 function findPreviousIndex (state) {
-  const files = TorrentSummary.getByKey(state, state.playing.infoHash).files.sort((a, b) => a.name.localeCompare(b.name))
+  const files = TorrentSummary.getByKey(state, state.playing.infoHash).files
+        .sort((a, b) => a.name.localeCompare(b.name))
   for (let i = state.playing.fileIndex - 1; i >= 0; i--) {
     if (TorrentPlayer.isPlayable(files[i])) return i
   }
@@ -79,7 +80,8 @@ function findPreviousIndex (state) {
 }
 
 function findNextIndex (state) {
-  const files = TorrentSummary.getByKey(state, state.playing.infoHash).files.sort((a, b) => a.name.localeCompare(b.name))
+  const files = TorrentSummary.getByKey(state, state.playing.infoHash).files
+        .sort((a, b) => a.name.localeCompare(b.name))
   for (let i = state.playing.fileIndex + 1; i < files.length; i++) {
     if (TorrentPlayer.isPlayable(files[i])) return i
   }

--- a/src/renderer/lib/playlist.js
+++ b/src/renderer/lib/playlist.js
@@ -71,7 +71,7 @@ function updateCache (state) {
 }
 
 function findPreviousIndex (state) {
-  const files = TorrentSummary.getByKey(state, state.playing.infoHash).files
+  const files = TorrentSummary.getByKey(state, state.playing.infoHash).files.sort((a, b) => a.name.localeCompare(b.name))
   for (let i = state.playing.fileIndex - 1; i >= 0; i--) {
     if (TorrentPlayer.isPlayable(files[i])) return i
   }
@@ -79,7 +79,7 @@ function findPreviousIndex (state) {
 }
 
 function findNextIndex (state) {
-  const files = TorrentSummary.getByKey(state, state.playing.infoHash).files
+  const files = TorrentSummary.getByKey(state, state.playing.infoHash).files.sort((a, b) => a.name.localeCompare(b.name))
   for (let i = state.playing.fileIndex + 1; i < files.length; i++) {
     if (TorrentPlayer.isPlayable(files[i])) return i
   }

--- a/src/renderer/pages/torrent-list-page.js
+++ b/src/renderer/pages/torrent-list-page.js
@@ -281,6 +281,7 @@ module.exports = class TorrentList extends React.Component {
       const fileRows = torrentSummary.files
         .filter((file) => !file.path.includes('/.____padding_file/'))
         .map((file, index) => ({ file, index }))
+        .sort((a, b) => a.file.name.localeCompare(b.file.name))
         .map((object) => this.renderFileRow(torrentSummary, object.file, object.index))
 
       filesElement = (

--- a/src/renderer/pages/torrent-list-page.js
+++ b/src/renderer/pages/torrent-list-page.js
@@ -280,8 +280,8 @@ module.exports = class TorrentList extends React.Component {
       // We do know the files. List them and show download stats for each one
       const fileRows = torrentSummary.files
         .filter((file) => !file.path.includes('/.____padding_file/'))
+        .sort((a, b) => a.name.localeCompare(b.name))
         .map((file, index) => ({ file, index }))
-        .sort((a, b) => a.file.name.localeCompare(b.file.name))
         .map((object) => this.renderFileRow(torrentSummary, object.file, object.index))
 
       filesElement = (


### PR DESCRIPTION
File names in a torrent are not sorted at the moment. This change adds sorting to file names by `String.localeCompare`.

Fixes: https://github.com/webtorrent/webtorrent-desktop/issues/1285