### PR TITLE
Remove 'video-on-top' from VLC player launch options

### DIFF
--- a/src/main/external-player.js
+++ b/src/main/external-player.js
@@ -29,7 +29,6 @@ function spawn (playerPath, url, title) {
     if (err) return windows.main.dispatch('externalPlayerNotFound')
     const args = [
       '--play-and-exit',
-      '--video-on-top',
       '--quiet',
       `--meta-title=${JSON.stringify(title)}`,
       url


### PR DESCRIPTION
This command line option just sets the 'Always on top' setting in VLC.
The player will pop up in the foreground when playing a video from webtorrent without this option.

Having VLC always on top is very annoying when multi tasking.
If the user wants VLC always on top, they can set it in VLC preferences.
