### PR TITLE
Fix the desktop file

### DIFF
--- a/static/linux/webtorrent-desktop.desktop
+++ b/static/linux/webtorrent-desktop.desktop
@@ -4,7 +4,6 @@ Version=1.0
 GenericName=BitTorrent Client
 X-GNOME-FullName=$APP_NAME
 Comment=Download and share files over BitTorrent
-Encoding=UTF-8
 Type=Application
 Icon=webtorrent-desktop
 Terminal=false
@@ -20,14 +19,11 @@ Actions=CreateNewTorrent;OpenTorrentFile;OpenTorrentAddress;
 [Desktop Action CreateNewTorrent]
 Name=Create New Torrent...
 Exec=$EXEC_PATH -n
-Path=$APP_PATH
 
 [Desktop Action OpenTorrentFile]
 Name=Open Torrent File...
 Exec=$EXEC_PATH -o
-Path=$APP_PATH
 
 [Desktop Action OpenTorrentAddress]
 Name=Open Torrent Address...
 Exec=$EXEC_PATH -u
-Path=$APP_PATH


### PR DESCRIPTION
If you run `desktop-file-validate` on the desktop file you will get this list of errors
```
 desktop-file-validate /usr/share/applications/webtorrent-desktop.desktop                                                         master    
/usr/share/applications/webtorrent-desktop.desktop: warning: key "Encoding" in group "Desktop Entry" is deprecated
/usr/share/applications/webtorrent-desktop.desktop: error: file contains key "Path" in group "Desktop Action CreateNewTorrent", but keys extending the format should start with "X-"
/usr/share/applications/webtorrent-desktop.desktop: error: file contains key "Path" in group "Desktop Action OpenTorrentFile", but keys extending the format should start with "X-"
/usr/share/applications/webtorrent-desktop.desktop: error: file contains key "Path" in group "Desktop Action OpenTorrentAddress", but keys extending the format should start with "X-"
```

This PR does:
- Remove the encoding key as it's not needed anymore
- Remove the Path key as it's not required, the group actions inherit the properties of their "parent"
