### PR TITLE
Fix external calls failing silently to open magnets

### DIFF
--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -461,7 +461,6 @@ function onOpen (files) {
 
   // File API seems to transform "magnet:?foo" in "magnet:///?foo"
   // this is a sanitization
-  console.log('------------- FILES', files)
   files = files.map(file => {
     if (typeof file !== 'string') return file
     return file.replace(/^magnet:\/+\?/i, 'magnet:?')

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -459,6 +459,14 @@ function setDimensions (dimensions) {
 function onOpen (files) {
   if (!Array.isArray(files)) files = [ files ]
 
+  // File API seems to transform "magnet:?foo" in "magnet:///?foo"
+  // this is a sanitization
+  console.log('------------- FILES', files)
+  files = files.map(file => {
+    if (typeof file !== 'string') return file
+    return file.replace(/^magnet:\/+\?/i, 'magnet:?')
+  })
+
   const url = state.location.url()
   const allTorrents = files.every(TorrentPlayer.isTorrent)
   const allSubtitles = files.every(controllers.subtitles().isSubtitle)


### PR DESCRIPTION
Original fix from @leodutra #1168.
I reapplied it on top of current `master`.
When testing I found that dropping `.torrent` files was breaking 😮 
So I added an additional fix to avoid trying to replace the conflicting string on torrent file objects.