### PR TITLE
Prevent spectrogram being selected as the poster.

### DIFF
--- a/src/renderer/lib/torrent-poster.js
+++ b/src/renderer/lib/torrent-poster.js
@@ -97,7 +97,8 @@ function scoreAudioCoverFile (imgFile) {
     folder: 80,
     album: 80,
     front: 80,
-    back: 20
+    back: 20,
+    spectrogram: -80
   }
 
   for (let keyword in relevanceScore) {


### PR DESCRIPTION
Related to:
- Improve poster selection: webtorrent/webtorrent-desktop#1332,
- pull request webtorrent/webtorrent-desktop#1334