### PR TITLE
Fix zero-padding logic on minutes

### DIFF
--- a/src/renderer/pages/player-page.js
+++ b/src/renderer/pages/player-page.js
@@ -719,9 +719,7 @@ function formatTime (time, total) {
   let totalMinutes = Math.floor(total % 3600 / 60)
   let hours = Math.floor(time / 3600)
   let minutes = Math.floor(time % 3600 / 60)
-  if (totalMinutes > 9) {
-    minutes = zeroFill(2, minutes)
-  }
+  minutes = zeroFill(2, minutes)
   let seconds = zeroFill(2, Math.floor(time % 60))
 
   return (totalHours > 0 ? hours + ':' : '') + minutes + ':' + seconds


### PR DESCRIPTION
Fixes https://github.com/webtorrent/webtorrent-desktop/issues/1438

The if statement was testing the opposite of the case it was supposed to test. Changing `>` to `<=` would fix the issue, but there's no reason to even have the conditional to begin with, since `zeroPad(2, 10) === '10'`