### PR TITLE
Borewit dependency/update music metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "location-history": "^1.0.0",
     "material-ui": "^0.17.0",
     "mkdirp": "^0.5.1",
-    "music-metadata": "^2.4.0",
+    "music-metadata": "^2.4.2",
     "network-address": "^1.1.0",
     "parse-torrent": "^6.0.1",
     "prettier-bytes": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "location-history": "^1.0.0",
     "material-ui": "^0.17.0",
     "mkdirp": "^0.5.1",
-    "music-metadata": "^2.0.1",
+    "music-metadata": "^2.3.2",
     "network-address": "^1.1.0",
     "parse-torrent": "^6.0.1",
     "prettier-bytes": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "location-history": "^1.0.0",
     "material-ui": "^0.17.0",
     "mkdirp": "^0.5.1",
-    "music-metadata": "^2.3.2",
+    "music-metadata": "^2.4.0",
     "network-address": "^1.1.0",
     "parse-torrent": "^6.0.1",
     "prettier-bytes": "^1.0.1",

--- a/src/renderer/controllers/playback-controller.js
+++ b/src/renderer/controllers/playback-controller.js
@@ -292,7 +292,7 @@ module.exports = class PlaybackController {
     }
 
     function getAudioMetadata () {
-      if (state.playing.type === 'audio' && !fileSummary.audioInfo) {
+      if (state.playing.type === 'audio') {
         ipcRenderer.send('wt-get-audio-metadata', torrentSummary.infoHash, index)
       }
     }

--- a/src/renderer/lib/torrent-poster.js
+++ b/src/renderer/lib/torrent-poster.js
@@ -4,8 +4,10 @@ const captureFrame = require('capture-frame')
 const path = require('path')
 
 const mediaExtensions = {
-  audio: ['.aac', '.asf', '.flac', '.m2a', '.m4a', '.m4b', '.mp2', '.mp4', '.mp3', '.oga', '.ogg', '.opus',
-    '.wma', '.wav', '.wv', '.wvp'],
+  audio: [
+    '.aac', '.asf', '.flac', '.m2a', '.m4a', '.m4b', '.mp2', '.mp4',
+    '.mp3', '.oga', '.ogg', '.opus', '.wma', '.wav', '.wv', '.wvp'
+  ],
   video: ['.mp4', '.m4v', '.webm', '.mov', '.mkv'],
   image: ['.gif', '.jpg', '.jpeg', '.png']
 }

--- a/src/renderer/lib/torrent-poster.js
+++ b/src/renderer/lib/torrent-poster.js
@@ -4,7 +4,7 @@ const captureFrame = require('capture-frame')
 const path = require('path')
 
 const mediaExtensions = {
-  audio: ['.aac', '.asf', '.flac', '.m2a', '.m4a', '.mp2', '.mp4', '.mp3', '.oga', '.ogg', '.opus',
+  audio: ['.aac', '.asf', '.flac', '.m2a', '.m4a', '.m4b', '.mp2', '.mp4', '.mp3', '.oga', '.ogg', '.opus',
     '.wma', '.wav', '.wv', '.wvp'],
   video: ['.mp4', '.m4v', '.webm', '.mov', '.mkv'],
   image: ['.gif', '.jpg', '.jpeg', '.png']

--- a/src/renderer/pages/player-page.js
+++ b/src/renderer/pages/player-page.js
@@ -286,10 +286,10 @@ function renderAudioMetadata (state) {
     format.push(fileSummary.audioInfo.format.dataformat)
   }
   if (fileSummary.audioInfo.format.bitrate) {
-    format.push(fileSummary.audioInfo.format.bitrate / 1000 + ' kbps')
+    format.push(Math.round(fileSummary.audioInfo.format.bitrate / 1000) + ' kbps') // 128 kbps
   }
   if (fileSummary.audioInfo.format.sampleRate) {
-    format.push(fileSummary.audioInfo.format.sampleRate / 1000 + ' kHz')
+    format.push(Math.round(fileSummary.audioInfo.format.sampleRate / 100) / 10 + ' kHz') // 44.1 kHz
   }
   if (fileSummary.audioInfo.format.bitsPerSample) {
     format.push(fileSummary.audioInfo.format.bitsPerSample + ' bit')


### PR DESCRIPTION
Here we can review the update I propose to ensure we always get proper audio metadata.
![image](https://user-images.githubusercontent.com/1118293/43049298-971409bc-8dcb-11e8-8330-f9e842f8b261.png)
