### PR TITLE
webtorrent/webtorrent-desktop#1340: Switch to async metadata updates.

### DIFF
--- a/src/renderer/pages/player-page.js
+++ b/src/renderer/pages/player-page.js
@@ -216,9 +216,7 @@ function renderAudioMetadata (state) {
   const elems = []
 
   // Audio metadata: artist(s)
-  const artist = common.albumartist || common.artist ||
-    (common.artists && common.artists.filter(function (a) { return a }).join(', ')) ||
-    '(Unknown Artist)'
+  const artist = common.artist || common.albumartist
   if (artist) {
     elems.push((
       <div key='artist' className='audio-artist'>


### PR DESCRIPTION
Implementation of asynchronous tag update events (send each time [music-metadata](https://github.com/Borewit/music-metadata) found a new tag while it is parsing the downloaded stream build up from the torrent chunks).

Solution for #1340: _Improve the music metadata reading and updating mechanism_

- [x] Add feature which allow async parser subscription: 
  - Issue: Borewit/music-metadata#125
  - Pull request: Borewit/music-metadata#126
  - Branch: [feature/async-updates](https://github.com/Borewit/music-metadata/tree/feature/async-updates)
- [ ] Review async concept
- [ ] Release version music-metadata with async observer API included
- [ ] Ready for merging