### PR TITLE
Auto populate 'Magnet Link' field with the address from clipboard #1162

### DIFF
--- a/src/renderer/components/open-torrent-address-modal.js
+++ b/src/renderer/components/open-torrent-address-modal.js
@@ -1,5 +1,6 @@
 const React = require('react')
 const TextField = require('material-ui/TextField').default
+const electron = require('electron')
 
 const ModalOKCancel = require('./modal-ok-cancel')
 const { dispatch, dispatcher } = require('../lib/dispatcher')
@@ -28,6 +29,11 @@ module.exports = class OpenTorrentAddressModal extends React.Component {
 
   componentDidMount () {
     this.torrentURL.input.focus()
+    const clipboardContent = electron.clipboard.readText()
+    if (clipboardContent.match(/magnet:\?xt=urn:[a-z0-9]+:[a-z0-9]{32}/i) !== null) {
+      this.torrentURL.input.value = clipboardContent
+      this.torrentURL.input.select()
+    }
   }
 }
 


### PR DESCRIPTION
If you have copied a magnet link to the clipboard, then File -> Open Torrent Address will automatically populate the address field with the copied address.

Closes #1162