### PR TITLE
Cleanup preferences page

### DIFF
--- a/src/renderer/components/path-selector.js
+++ b/src/renderer/components/path-selector.js
@@ -1,3 +1,5 @@
+const path = require('path')
+
 const colors = require('material-ui/styles/colors')
 const electron = require('electron')
 const React = require('react')
@@ -31,8 +33,8 @@ class PathSelector extends React.Component {
 
   handleClick () {
     const opts = Object.assign({
-      defaultPath: this.props.value,
-      properties: ['openFile', 'openDirectory']
+      defaultPath: this.props.value && path.dirname(this.props.value),
+      properties: [ 'openFile', 'openDirectory' ]
     }, this.props.dialog)
 
     remote.dialog.showOpenDialog(

--- a/src/renderer/components/path-selector.js
+++ b/src/renderer/components/path-selector.js
@@ -18,7 +18,6 @@ class PathSelector extends React.Component {
     return {
       className: PropTypes.string,
       dialog: PropTypes.object,
-      displayValue: PropTypes.string,
       id: PropTypes.string,
       onChange: PropTypes.func,
       title: PropTypes.string.isRequired,
@@ -34,7 +33,7 @@ class PathSelector extends React.Component {
   handleClick () {
     const opts = Object.assign({
       defaultPath: this.props.value && path.dirname(this.props.value),
-      properties: [ 'openFile', 'openDirectory' ]
+      properties: ['openFile', 'openDirectory']
     }, this.props.dialog)
 
     remote.dialog.showOpenDialog(
@@ -67,8 +66,7 @@ class PathSelector extends React.Component {
     const textFieldStyle = {
       flex: '1'
     }
-
-    const text = this.props.displayValue || this.props.value || ''
+    const text = this.props.value || ''
     const buttonStyle = {
       marginLeft: 10
     }

--- a/src/renderer/pages/preferences-page.js
+++ b/src/renderer/pages/preferences-page.js
@@ -1,4 +1,3 @@
-const path = require('path')
 const React = require('react')
 const PropTypes = require('prop-types')
 
@@ -105,7 +104,7 @@ class PreferencesPage extends React.Component {
           displayValue={playerName}
           onChange={this.handleExternalPlayerPathChange}
           title='External player'
-          value={playerPath ? path.dirname(playerPath) : null}
+          value={playerPath}
         />
       </Preference>
     )
@@ -139,11 +138,11 @@ class PreferencesPage extends React.Component {
     dispatch('updatePreferences', 'autoAddTorrents', isChecked)
 
     if (isChecked) {
-      dispatch('startFolderWatcher', null)
+      dispatch('startFolderWatcher')
       return
     }
 
-    dispatch('stopFolderWatcher', null)
+    dispatch('stopFolderWatcher')
   }
 
   torrentsFolderPathSelector () {
@@ -156,10 +155,9 @@ class PreferencesPage extends React.Component {
             title: 'Select folder to watch for new torrents',
             properties: ['openDirectory']
           }}
-          displayValue={torrentsFolderPath || ''}
           onChange={this.handleTorrentsFolderPathChange}
           title='Folder to watch'
-          value={torrentsFolderPath ? path.dirname(torrentsFolderPath) : null}
+          value={torrentsFolderPath}
         />
       </Preference>
     )

--- a/src/renderer/pages/preferences-page.js
+++ b/src/renderer/pages/preferences-page.js
@@ -101,7 +101,6 @@ class PreferencesPage extends React.Component {
             title: 'Select media player app',
             properties: ['openFile']
           }}
-          displayValue={playerName}
           onChange={this.handleExternalPlayerPathChange}
           title='External player'
           value={playerPath}


### PR DESCRIPTION
- Moves path logic to PathSelector component
- Removes `displayValue`, and always shows path instead.

I think it makes sense to remove `displayValue`, because it's only used to display the name of the external player, which is inconsistent with how we display other paths.
Also, the player name is already displayed in a message above the path, so we don't lose that information.