### PR TITLE
Ensure that the minutes field in playback indicator is zero-padded.

### DIFF
--- a/src/renderer/pages/player-page.js
+++ b/src/renderer/pages/player-page.js
@@ -735,7 +735,7 @@ function formatTime (time, total) {
   }
 
   const totalHours = Math.floor(total / 3600)
-  const totalMinutes = Math.floor(total % 3600 / 60)
+  const totalMinutes = Math.floor(total / 60)
   const hours = Math.floor(time / 3600)
   let minutes = Math.floor(time % 3600 / 60)
   if (totalMinutes > 9) {


### PR DESCRIPTION
The minutes field should be zero-padded as long as the playback media is longer than 9 minutes (including hours).

Fixes #1438.