### PR TITLE
Cleanup edit menu

### DIFF
--- a/src/main/menu.js
+++ b/src/main/menu.js
@@ -121,29 +121,8 @@ function getMenuTemplate () {
       label: 'Edit',
       submenu: [
         {
-          role: 'undo'
-        },
-        {
-          role: 'redo'
-        },
-        {
-          type: 'separator'
-        },
-        {
-          role: 'cut'
-        },
-        {
-          role: 'copy'
-        },
-        {
           label: 'Paste Torrent Address',
           role: 'paste'
-        },
-        {
-          role: 'delete'
-        },
-        {
-          role: 'selectall'
         }
       ]
     },


### PR DESCRIPTION
Related to #1500 and #1239.

I don't think those edit submenus serve any purpose. I believe it would be better to remove them.