### PR TITLE
Update music-metadata to 3.5.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1618,7 +1618,8 @@
             "ansi-regex": {
               "version": "2.1.1",
               "resolved": false,
-              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -1639,12 +1640,14 @@
             "balanced-match": {
               "version": "1.0.0",
               "resolved": false,
-              "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+              "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "resolved": false,
               "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -1659,17 +1662,20 @@
             "code-point-at": {
               "version": "1.1.0",
               "resolved": false,
-              "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+              "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
               "resolved": false,
-              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "resolved": false,
-              "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+              "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -1786,7 +1792,8 @@
             "inherits": {
               "version": "2.0.3",
               "resolved": false,
-              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -1798,6 +1805,7 @@
               "version": "1.0.0",
               "resolved": false,
               "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -1812,6 +1820,7 @@
               "version": "3.0.4",
               "resolved": false,
               "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -1819,12 +1828,14 @@
             "minimist": {
               "version": "0.0.8",
               "resolved": false,
-              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+              "optional": true
             },
             "minipass": {
               "version": "2.2.4",
               "resolved": false,
               "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.1",
                 "yallist": "^3.0.0"
@@ -1843,6 +1854,7 @@
               "version": "0.5.1",
               "resolved": false,
               "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -1923,7 +1935,8 @@
             "number-is-nan": {
               "version": "1.0.1",
               "resolved": false,
-              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -1935,6 +1948,7 @@
               "version": "1.4.0",
               "resolved": false,
               "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -2020,7 +2034,8 @@
             "safe-buffer": {
               "version": "5.1.1",
               "resolved": false,
-              "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+              "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -2056,6 +2071,7 @@
               "version": "1.0.2",
               "resolved": false,
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -2075,6 +2091,7 @@
               "version": "3.0.1",
               "resolved": false,
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -2118,12 +2135,14 @@
             "wrappy": {
               "version": "1.0.2",
               "resolved": false,
-              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+              "optional": true
             },
             "yallist": {
               "version": "3.0.2",
               "resolved": false,
-              "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
+              "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
+              "optional": true
             }
           }
         },
@@ -4007,9 +4026,9 @@
       }
     },
     "file-type": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-10.6.0.tgz",
-      "integrity": "sha512-GNOg09GC+rZzxetGZFoL7QOnWXRqvWuEdKURIJlr0d6MW107Iwy6voG1PPOrm5meG6ls59WkBmBMAZdVSVajRQ=="
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-10.7.0.tgz",
+      "integrity": "sha512-AbaGtdWYYRaVrv2MwL/65myuRJ9j3e79e7etJ79US18QHuVlzJBcQHUH+HxDUoLtbyWRTUfLzLkGXX3pP9kfZg=="
     },
     "filestream": {
       "version": "4.1.3",
@@ -6058,7 +6077,7 @@
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
     "mediasource": {
@@ -6374,9 +6393,9 @@
       }
     },
     "music-metadata": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/music-metadata/-/music-metadata-3.3.0.tgz",
-      "integrity": "sha512-b5My8m7R2DyrOKlHGOyXva73gRsnJbZi6Sq427fPJjQ7OxiU8xS56Q9d16KEOwr0XLKALWW3fI8zMce5SM71ag==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/music-metadata/-/music-metadata-3.4.1.tgz",
+      "integrity": "sha512-zuoeD1ctfEGw4gHdQtnm7Os+ZoY6m7c5uSLuHBx07ckq3KodH0ICuoE4nkk76niBrk/yUcK/bHhxHsjn5j6uuQ==",
       "requires": {
         "debug": "^4.1.0",
         "file-type": "^10.5.0",
@@ -6386,9 +6405,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
-          "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "requires": {
             "ms": "^2.1.1"
           }
@@ -6409,8 +6428,7 @@
     "nan": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.0.tgz",
-      "integrity": "sha512-F4miItu2rGnV2ySkXOQoA8FKz/SR2Q2sWP0sbTxNxz/tuokeC8WxOhPMcwi0qIyGtVn/rrSeLbvVkznqCdwYnw==",
-      "optional": true
+      "integrity": "sha512-F4miItu2rGnV2ySkXOQoA8FKz/SR2Q2sWP0sbTxNxz/tuokeC8WxOhPMcwi0qIyGtVn/rrSeLbvVkznqCdwYnw=="
     },
     "nan-x": {
       "version": "1.0.2",
@@ -7036,8 +7054,7 @@
     "path-key": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-1.0.0.tgz",
-      "integrity": "sha1-XVPVeAGWRsDWiADbThRua9wqx68=",
-      "optional": true
+      "integrity": "sha1-XVPVeAGWRsDWiADbThRua9wqx68="
     },
     "path-parse": {
       "version": "1.0.6",
@@ -9038,9 +9055,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
-          "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "requires": {
             "ms": "^2.1.1"
           }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4026,9 +4026,9 @@
       }
     },
     "file-type": {
-      "version": "10.7.0",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-10.7.0.tgz",
-      "integrity": "sha512-AbaGtdWYYRaVrv2MwL/65myuRJ9j3e79e7etJ79US18QHuVlzJBcQHUH+HxDUoLtbyWRTUfLzLkGXX3pP9kfZg=="
+      "version": "10.9.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-10.9.0.tgz",
+      "integrity": "sha512-9C5qtGR/fNibHC5gzuMmmgnjH3QDDLKMa8lYe9CiZVmAnI4aUaoMh40QyUPzzs0RYo837SOBKh7TYwle4G8E4w=="
     },
     "filestream": {
       "version": "4.1.3",
@@ -6077,7 +6077,7 @@
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
     "mediasource": {
@@ -6393,9 +6393,9 @@
       }
     },
     "music-metadata": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/music-metadata/-/music-metadata-3.4.1.tgz",
-      "integrity": "sha512-zuoeD1ctfEGw4gHdQtnm7Os+ZoY6m7c5uSLuHBx07ckq3KodH0ICuoE4nkk76niBrk/yUcK/bHhxHsjn5j6uuQ==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/music-metadata/-/music-metadata-3.5.2.tgz",
+      "integrity": "sha512-XiqnSzysdMSUHMHAZ1dhvBoFD/Mmn1pIBN+sOp32XBtD1+eYjSdkAO3bvBaO+21WKS5Q6B6fuEnclY3U+Kq7wA==",
       "requires": {
         "debug": "^4.1.0",
         "file-type": "^10.5.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "location-history": "^1.0.0",
     "material-ui": "^0.20.2",
     "mkdirp": "^0.5.1",
-    "music-metadata": "^3.3.0",
+    "music-metadata": "^3.4.1",
     "network-address": "^1.1.0",
     "parse-torrent": "^6.0.1",
     "prettier-bytes": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "location-history": "^1.0.0",
     "material-ui": "^0.20.2",
     "mkdirp": "^0.5.1",
-    "music-metadata": "^3.4.1",
+    "music-metadata": "^3.5.2",
     "network-address": "^1.1.0",
     "parse-torrent": "^6.0.1",
     "prettier-bytes": "^1.0.1",


### PR DESCRIPTION
Changes:

* Improve .m4a (MPEG-4) format information
  * Provide bitrate
  * Provide MPEG-4 codec (data format) information

![2019-01-01 web-torrent m4a codec bit-rate](https://user-images.githubusercontent.com/23255260/50574598-de537d80-0deb-11e9-80bd-1868ea1f4337.jpg)

