### PR TITLE
Add preference option to sort files by name, size, or default

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1639,12 +1639,14 @@
             "balanced-match": {
               "version": "1.0.0",
               "resolved": false,
-              "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+              "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "resolved": false,
               "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -1659,17 +1661,20 @@
             "code-point-at": {
               "version": "1.1.0",
               "resolved": false,
-              "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+              "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
               "resolved": false,
-              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "resolved": false,
-              "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+              "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -1786,7 +1791,8 @@
             "inherits": {
               "version": "2.0.3",
               "resolved": false,
-              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -1798,6 +1804,7 @@
               "version": "1.0.0",
               "resolved": false,
               "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -1812,6 +1819,7 @@
               "version": "3.0.4",
               "resolved": false,
               "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -1923,7 +1931,8 @@
             "number-is-nan": {
               "version": "1.0.1",
               "resolved": false,
-              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -1935,6 +1944,7 @@
               "version": "1.4.0",
               "resolved": false,
               "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -2056,6 +2066,7 @@
               "version": "1.0.2",
               "resolved": false,
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -4703,6 +4714,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
       "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
+      "optional": true,
       "requires": {
         "has-symbol-support-x": "^1.4.1"
       }
@@ -5286,6 +5298,7 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/is-function-x/-/is-function-x-3.3.0.tgz",
       "integrity": "sha512-SreSSU1dlgYaXR5c0mm4qJHKYHIiGiEY+7Cd8/aRLLoMP/VvofD2XcWgBnP833ajpU5XzXbUSpfysnfKZLJFlg==",
+      "optional": true,
       "requires": {
         "attempt-x": "^1.1.1",
         "has-to-string-tag-x": "^1.4.1",
@@ -5350,7 +5363,8 @@
     "is-nan-x": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-nan-x/-/is-nan-x-1.0.3.tgz",
-      "integrity": "sha512-WenNBLVGSZID8shogsB++42vF7gvotCfneXM9KMCAKwNPXa8VfAu/RWwpqvnK7dLOP4Z7uitocb0TZ6rAiOccA=="
+      "integrity": "sha512-WenNBLVGSZID8shogsB++42vF7gvotCfneXM9KMCAKwNPXa8VfAu/RWwpqvnK7dLOP4Z7uitocb0TZ6rAiOccA==",
+      "optional": true
     },
     "is-nil-x": {
       "version": "1.4.2",
@@ -6606,6 +6620,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-space-x/-/normalize-space-x-3.0.0.tgz",
       "integrity": "sha512-tbCJerqZCCHPst4rRKgsTanLf45fjOyeAU5zE3mhDxJtFJKt66q39g2XArWhXelgTFVib8mNBUm6Wrd0LxYcfQ==",
+      "optional": true,
       "requires": {
         "cached-constructors-x": "^1.0.0",
         "trim-x": "^3.0.0",
@@ -6955,6 +6970,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/parse-int-x/-/parse-int-x-2.0.0.tgz",
       "integrity": "sha512-NIMm52gmd1+0qxJK8lV3OZ4zzWpRH1xcz9xCHXl+DNzddwUdS4NEtd7BmTeK7iCIXoaK5e6BoDMHgieH2eNIhg==",
+      "optional": true,
       "requires": {
         "cached-constructors-x": "^1.0.0",
         "nan-x": "^1.0.0",
@@ -7827,6 +7843,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/replace-comments-x/-/replace-comments-x-2.0.0.tgz",
       "integrity": "sha512-+vMP4jqU+8HboLWms6YMNEiaZG5hh1oR6ENCnGYDF/UQ7aYiJUK/8tcl3+KZAHRCKKa3gqzrfiarlUBHQSgRlg==",
+      "optional": true,
       "requires": {
         "require-coercible-to-string-x": "^1.0.0",
         "to-string-x": "^1.4.2"
@@ -9428,6 +9445,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-2.0.0.tgz",
       "integrity": "sha512-lGOnCoccUoSzjZ/9Uen8TC4+VFaQcFGhTroWTv2tYWxXgyJV1zqAZ8hEIMkez/Eo790fBMOjidTnQ/OJSCvAoQ==",
+      "optional": true,
       "requires": {
         "cached-constructors-x": "^1.0.0",
         "nan-x": "^1.0.0",
@@ -9448,6 +9466,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/to-object-x/-/to-object-x-1.5.0.tgz",
       "integrity": "sha512-AKn5GQcdWky+s20vjWkt+Wa6y3dxQH3yQyMBhOfBOPldUwqwhgvlqcIg5H092ntNc+TX8/Cxzs1kMHH19pyCnA==",
+      "optional": true,
       "requires": {
         "cached-constructors-x": "^1.0.0",
         "require-object-coercible-x": "^1.4.1"
@@ -9457,6 +9476,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/to-primitive-x/-/to-primitive-x-1.1.0.tgz",
       "integrity": "sha512-gyMY0gi3wjK3e4MUBKqv9Zl8QGcWguIkaUr2VJmoBEsOpDcpDZSEyljR773eVG4maS48uX7muLkoQoh/BA82OQ==",
+      "optional": true,
       "requires": {
         "has-symbol-support-x": "^1.4.1",
         "is-date-object": "^1.0.1",
@@ -9472,6 +9492,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/to-property-key-x/-/to-property-key-x-2.0.2.tgz",
       "integrity": "sha512-YISLpZFYIazNm0P8hLsKEEUEZ3m8U3+eDysJZqTu3+B9tQp+2TrMpaEGT8Agh4fZ5LSoums60/glNEzk5ozqrg==",
+      "optional": true,
       "requires": {
         "has-symbol-support-x": "^1.4.1",
         "to-primitive-x": "^1.1.0",
@@ -9573,6 +9594,7 @@
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/to-string-tag-x/-/to-string-tag-x-1.4.2.tgz",
       "integrity": "sha512-ytO9eLigxsQQLGuab0C1iSSTzKdJNVSlBg0Spg4J/rGAVrQJ5y774mo0SSzgGeTT4RJGGyJNfObXaTMzX0XDOQ==",
+      "optional": true,
       "requires": {
         "lodash.isnull": "^3.0.0",
         "validate.io-undefined": "^1.0.3"

--- a/src/renderer/pages/preferences-page.js
+++ b/src/renderer/pages/preferences-page.js
@@ -81,7 +81,7 @@ class PreferencesPage extends React.Component {
     dispatch('updatePreferences', 'highestPlaybackPriority', isChecked)
   }
 
-  sortFilesByCheckboxes() {
+  sortFilesByCheckboxes () {
     const checked = this.props.state.saved.prefs.sortFilesBy
     return (
       <Preference>
@@ -101,7 +101,7 @@ class PreferencesPage extends React.Component {
     )
   }
 
-  handleSortFilesByChange(type, isChecked) {
+  handleSortFilesByChange (type, isChecked) {
     dispatch('updatePreferences', 'sortFilesBy', isChecked ? type : undefined)
   }
 

--- a/src/renderer/pages/preferences-page.js
+++ b/src/renderer/pages/preferences-page.js
@@ -81,6 +81,30 @@ class PreferencesPage extends React.Component {
     dispatch('updatePreferences', 'highestPlaybackPriority', isChecked)
   }
 
+  sortFilesByCheckboxes() {
+    const checked = this.props.state.saved.prefs.sortFilesBy
+    return (
+      <Preference>
+        <Checkbox
+          className='control'
+          checked={checked === 'name'}
+          label={'Sort by file name'}
+          onCheck={(e, isChecked) => this.handleSortFilesByChange('name', isChecked)}
+        />
+        <Checkbox
+          className='control'
+          checked={checked === 'size'}
+          label={'Sort by file size'}
+          onCheck={(e, isChecked) => this.handleSortFilesByChange('size', isChecked)}
+        />
+      </Preference>
+    )
+  }
+
+  handleSortFilesByChange(type, isChecked) {
+    dispatch('updatePreferences', 'sortFilesBy', isChecked ? type : undefined)
+  }
+
   externalPlayerPathSelector () {
     const playerPath = this.props.state.saved.prefs.externalPlayerPath
     const playerName = this.props.state.getExternalPlayerName()
@@ -226,6 +250,9 @@ class PreferencesPage extends React.Component {
           {this.openExternalPlayerCheckbox()}
           {this.externalPlayerPathSelector()}
           {this.highestPlaybackPriorityCheckbox()}
+        </PreferencesSection>
+        <PreferencesSection title='File sorting'>
+          {this.sortFilesByCheckboxes()}
         </PreferencesSection>
         <PreferencesSection title='Default torrent app'>
           {this.setDefaultAppButton()}

--- a/src/renderer/pages/preferences-page.js
+++ b/src/renderer/pages/preferences-page.js
@@ -97,6 +97,7 @@ class PreferencesPage extends React.Component {
           label={'Sort by file size'}
           onCheck={(e, isChecked) => this.handleSortFilesByChange('size', isChecked)}
         />
+        <p>Choose how a torrent's files should be sorted.</p>
       </Preference>
     )
   }

--- a/src/renderer/pages/torrent-list-page.js
+++ b/src/renderer/pages/torrent-list-page.js
@@ -303,7 +303,7 @@ module.exports = class TorrentList extends React.Component {
   }
 
   getFileSortingFunction () {
-    switch (this.state.saved.prefs.sortFilesBy) {
+    switch (this.props.state.saved.prefs.sortFilesBy) {
       case 'size':
         return (a, b) => b.length - a.length
       case 'name':

--- a/src/renderer/pages/torrent-list-page.js
+++ b/src/renderer/pages/torrent-list-page.js
@@ -280,6 +280,7 @@ module.exports = class TorrentList extends React.Component {
       // We do know the files. List them and show download stats for each one
       const fileRows = torrentSummary.files
         .filter((file) => !file.path.includes('/.____padding_file/'))
+        .sort(this.getFileSortingFunction())
         .map((file, index) => ({ file, index }))
         .map((object) => this.renderFileRow(torrentSummary, object.file, object.index))
 
@@ -299,6 +300,17 @@ module.exports = class TorrentList extends React.Component {
         {filesElement}
       </div>
     )
+  }
+
+  getFileSortingFunction() {
+      switch (state.saved.prefs.sortFilesBy) {
+        case 'size':
+          return (a, b) => b.length - a.length
+        case 'name':
+          return (a, b) => a.name.localeCompare(b.name)
+        default:
+          return () => 0
+      }
   }
 
   // Show a single torrentSummary file in the details view for a single torrent

--- a/src/renderer/pages/torrent-list-page.js
+++ b/src/renderer/pages/torrent-list-page.js
@@ -280,8 +280,8 @@ module.exports = class TorrentList extends React.Component {
       // We do know the files. List them and show download stats for each one
       const fileRows = torrentSummary.files
         .filter((file) => !file.path.includes('/.____padding_file/'))
-        .sort(this.getFileSortingFunction())
         .map((file, index) => ({ file, index }))
+        .sort(this.getFileSortingFunction())
         .map((object) => this.renderFileRow(torrentSummary, object.file, object.index))
 
       filesElement = (
@@ -305,9 +305,9 @@ module.exports = class TorrentList extends React.Component {
   getFileSortingFunction () {
     switch (this.props.state.saved.prefs.sortFilesBy) {
       case 'size':
-        return (a, b) => b.length - a.length
+        return (a, b) => b.file.length - a.file.length
       case 'name':
-        return (a, b) => a.name.localeCompare(b.name)
+        return (a, b) => a.file.name.localeCompare(b.file.name)
       default:
         return () => 0
     }

--- a/src/renderer/pages/torrent-list-page.js
+++ b/src/renderer/pages/torrent-list-page.js
@@ -302,15 +302,15 @@ module.exports = class TorrentList extends React.Component {
     )
   }
 
-  getFileSortingFunction() {
-      switch (state.saved.prefs.sortFilesBy) {
-        case 'size':
-          return (a, b) => b.length - a.length
-        case 'name':
-          return (a, b) => a.name.localeCompare(b.name)
-        default:
-          return () => 0
-      }
+  getFileSortingFunction () {
+    switch (this.state.saved.prefs.sortFilesBy) {
+      case 'size':
+        return (a, b) => b.length - a.length
+      case 'name':
+        return (a, b) => a.name.localeCompare(b.name)
+      default:
+        return () => 0
+    }
   }
 
   // Show a single torrentSummary file in the details view for a single torrent


### PR DESCRIPTION
I know it has been requested numerous times to sort files alphanumerically because it can be very frustrating to stream a season of a show and you have to look very hard to find the episode you need. In this PR, I allow users to have the option to sort by file name or file size. The files are not sorted by default so it should not change the user experience unless they seek the option.

In response to [this](https://github.com/webtorrent/webtorrent-desktop/pull/1188#issuecomment-315634680): 
>Thank you for your PR. We want to keep a simple UI, with not a lot of configuration. It would be cool to offer the possibility to extend config with extensions.

This doesn't add any other dependencies and keeps the main UI completely the same.