### PR TITLE
Update copyright for 2019

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -23,7 +23,7 @@ module.exports = {
   CRASH_REPORT_URL: 'https://webtorrent.io/desktop/crash-report',
   TELEMETRY_URL: 'https://webtorrent.io/desktop/telemetry',
 
-  APP_COPYRIGHT: 'Copyright © 2014-2018 ' + APP_TEAM,
+  APP_COPYRIGHT: 'Copyright © 2014-2019 ' + APP_TEAM,
   APP_FILE_ICON: path.join(__dirname, '..', 'static', 'WebTorrentFile'),
   APP_ICON: path.join(__dirname, '..', 'static', 'WebTorrent'),
   APP_NAME: APP_NAME,


### PR DESCRIPTION
1 character fix to update the copyright line from `2014-2018` to `2014-2019` 💅 

Here are the two places this value is used: https://github.com/webtorrent/webtorrent-desktop/search?q=APP_COPYRIGHT&unscoped_q=APP_COPYRIGHT

Happy new year everybody 🎉🍾🚀 