### PR TITLE
Update music metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4028,9 +4028,9 @@
       }
     },
     "file-type": {
-      "version": "10.9.0",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-10.9.0.tgz",
-      "integrity": "sha512-9C5qtGR/fNibHC5gzuMmmgnjH3QDDLKMa8lYe9CiZVmAnI4aUaoMh40QyUPzzs0RYo837SOBKh7TYwle4G8E4w=="
+      "version": "10.11.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-10.11.0.tgz",
+      "integrity": "sha512-uzk64HRpUZyTGZtVuvrjP0FYxzQrBf4rojot6J65YMEbwBLB0CWm0CLojVpwpmFmxcE/lkvYICgfcGozbBq6rw=="
     },
     "filestream": {
       "version": "4.1.3",
@@ -6403,9 +6403,9 @@
       }
     },
     "music-metadata": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/music-metadata/-/music-metadata-3.5.2.tgz",
-      "integrity": "sha512-XiqnSzysdMSUHMHAZ1dhvBoFD/Mmn1pIBN+sOp32XBtD1+eYjSdkAO3bvBaO+21WKS5Q6B6fuEnclY3U+Kq7wA==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/music-metadata/-/music-metadata-3.6.1.tgz",
+      "integrity": "sha512-lPp5g64NdpX4ZVLopt5ZdNXkefhrfJGqzNuAtDPMUs9NrRzn7MAvHqMFrhefpmyvEEUcptDaQMRUMupnugdKmw==",
       "requires": {
         "debug": "^4.1.0",
         "file-type": "^10.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -697,7 +697,8 @@
     "attempt-x": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/attempt-x/-/attempt-x-1.1.3.tgz",
-      "integrity": "sha512-y/+ek8IjxVpTbj/phC87jK5YRhlP5Uu7FlQdCmYuut1DTjNruyrGqUWi5bcX1VKsQX1B0FX16A1hqHomKpHv3A=="
+      "integrity": "sha512-y/+ek8IjxVpTbj/phC87jK5YRhlP5Uu7FlQdCmYuut1DTjNruyrGqUWi5bcX1VKsQX1B0FX16A1hqHomKpHv3A==",
+      "optional": true
     },
     "auto-launch": {
       "version": "5.0.5",
@@ -1461,7 +1462,8 @@
     "cached-constructors-x": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/cached-constructors-x/-/cached-constructors-x-1.0.2.tgz",
-      "integrity": "sha512-7lKwmwXweW6E/31RHAJemLtZPfb2xvcABXknFF4b/dNYv4DbSGTgQHckXLQkNw6BB4HKFYW6mJgsNjADAy1ehw=="
+      "integrity": "sha512-7lKwmwXweW6E/31RHAJemLtZPfb2xvcABXknFF4b/dNYv4DbSGTgQHckXLQkNw6BB4HKFYW6mJgsNjADAy1ehw==",
+      "optional": true
     },
     "caller-path": {
       "version": "0.1.0",
@@ -1611,25 +1613,25 @@
           "dependencies": {
             "abbrev": {
               "version": "1.1.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
               "optional": true
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
               "optional": true
             },
             "aproba": {
               "version": "1.2.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
               "optional": true
             },
             "are-we-there-yet": {
               "version": "1.1.4",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
               "optional": true,
               "requires": {
@@ -1639,13 +1641,13 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
               "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
               "optional": true,
               "requires": {
@@ -1655,37 +1657,37 @@
             },
             "chownr": {
               "version": "1.0.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
               "optional": true
             },
             "code-point-at": {
               "version": "1.1.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
               "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
               "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
               "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
               "optional": true
             },
             "debug": {
               "version": "2.6.9",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
               "optional": true,
               "requires": {
@@ -1694,25 +1696,25 @@
             },
             "deep-extend": {
               "version": "0.5.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w==",
               "optional": true
             },
             "delegates": {
               "version": "1.0.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
               "optional": true
             },
             "detect-libc": {
               "version": "1.0.3",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
               "optional": true
             },
             "fs-minipass": {
               "version": "1.2.5",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
               "optional": true,
               "requires": {
@@ -1721,13 +1723,13 @@
             },
             "fs.realpath": {
               "version": "1.0.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
               "optional": true
             },
             "gauge": {
               "version": "2.7.4",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
               "optional": true,
               "requires": {
@@ -1743,7 +1745,7 @@
             },
             "glob": {
               "version": "7.1.2",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
               "optional": true,
               "requires": {
@@ -1757,13 +1759,13 @@
             },
             "has-unicode": {
               "version": "2.0.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
               "optional": true
             },
             "iconv-lite": {
               "version": "0.4.21",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-En5V9za5mBt2oUA03WGD3TwDv0MKAruqsuxstbMUZaj9W9k/m1CV/9py3l0L5kw9Bln8fdHQmzHSYtvpvTLpKw==",
               "optional": true,
               "requires": {
@@ -1772,7 +1774,7 @@
             },
             "ignore-walk": {
               "version": "3.0.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
               "optional": true,
               "requires": {
@@ -1781,7 +1783,7 @@
             },
             "inflight": {
               "version": "1.0.6",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
               "optional": true,
               "requires": {
@@ -1791,19 +1793,19 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
               "optional": true
             },
             "ini": {
               "version": "1.3.5",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
               "optional": true
             },
             "is-fullwidth-code-point": {
               "version": "1.0.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
               "optional": true,
               "requires": {
@@ -1812,13 +1814,13 @@
             },
             "isarray": {
               "version": "1.0.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
               "optional": true
             },
             "minimatch": {
               "version": "3.0.4",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
               "optional": true,
               "requires": {
@@ -1827,13 +1829,13 @@
             },
             "minimist": {
               "version": "0.0.8",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
               "optional": true
             },
             "minipass": {
               "version": "2.2.4",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
               "optional": true,
               "requires": {
@@ -1843,7 +1845,7 @@
             },
             "minizlib": {
               "version": "1.1.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
               "optional": true,
               "requires": {
@@ -1852,7 +1854,7 @@
             },
             "mkdirp": {
               "version": "0.5.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
               "optional": true,
               "requires": {
@@ -1861,13 +1863,13 @@
             },
             "ms": {
               "version": "2.0.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
               "optional": true
             },
             "needle": {
               "version": "2.2.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-eFagy6c+TYayorXw/qtAdSvaUpEbBsDwDyxYFgLZ0lTojfH7K+OdBqAF7TAFwDokJaGpubpSGG0wO3iC0XPi8w==",
               "optional": true,
               "requires": {
@@ -1878,7 +1880,7 @@
             },
             "node-pre-gyp": {
               "version": "0.10.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-G7kEonQLRbcA/mOoFoxvlMrw6Q6dPf92+t/l0DFSMuSlDoWaI9JWIyPwK0jyE1bph//CUEL65/Fz1m2vJbmjQQ==",
               "optional": true,
               "requires": {
@@ -1896,7 +1898,7 @@
             },
             "nopt": {
               "version": "4.0.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
               "optional": true,
               "requires": {
@@ -1906,13 +1908,13 @@
             },
             "npm-bundled": {
               "version": "1.0.3",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-ByQ3oJ/5ETLyglU2+8dBObvhfWXX8dtPZDMePCahptliFX2iIuhyEszyFk401PZUNQH20vvdW5MLjJxkwU80Ow==",
               "optional": true
             },
             "npm-packlist": {
               "version": "1.1.10",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-AQC0Dyhzn4EiYEfIUjCdMl0JJ61I2ER9ukf/sLxJUcZHfo+VyEfz2rMJgLZSS1v30OxPQe1cN0LZA1xbcaVfWA==",
               "optional": true,
               "requires": {
@@ -1922,7 +1924,7 @@
             },
             "npmlog": {
               "version": "4.1.2",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
               "optional": true,
               "requires": {
@@ -1934,19 +1936,19 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
               "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
               "optional": true
             },
             "once": {
               "version": "1.4.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
               "optional": true,
               "requires": {
@@ -1955,19 +1957,19 @@
             },
             "os-homedir": {
               "version": "1.0.2",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
               "optional": true
             },
             "os-tmpdir": {
               "version": "1.0.2",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
               "optional": true
             },
             "osenv": {
               "version": "0.1.5",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
               "optional": true,
               "requires": {
@@ -1977,19 +1979,19 @@
             },
             "path-is-absolute": {
               "version": "1.0.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
               "optional": true
             },
             "process-nextick-args": {
               "version": "2.0.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
               "optional": true
             },
             "rc": {
               "version": "1.2.7",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-LdLD8xD4zzLsAT5xyushXDNscEjB7+2ulnl8+r1pnESlYtlJtVSoCMBGr30eDRJ3+2Gq89jK9P9e4tCEH1+ywA==",
               "optional": true,
               "requires": {
@@ -2001,7 +2003,7 @@
               "dependencies": {
                 "minimist": {
                   "version": "1.2.0",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
                   "optional": true
                 }
@@ -2009,7 +2011,7 @@
             },
             "readable-stream": {
               "version": "2.3.6",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "optional": true,
               "requires": {
@@ -2024,7 +2026,7 @@
             },
             "rimraf": {
               "version": "2.6.2",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
               "optional": true,
               "requires": {
@@ -2033,43 +2035,43 @@
             },
             "safe-buffer": {
               "version": "5.1.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
               "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
               "optional": true
             },
             "sax": {
               "version": "1.2.4",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
               "optional": true
             },
             "semver": {
               "version": "5.5.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
               "optional": true
             },
             "set-blocking": {
               "version": "2.0.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
               "optional": true
             },
             "signal-exit": {
               "version": "3.0.2",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
               "optional": true
             },
             "string-width": {
               "version": "1.0.2",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "optional": true,
               "requires": {
@@ -2080,7 +2082,7 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "optional": true,
               "requires": {
@@ -2089,7 +2091,7 @@
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "optional": true,
               "requires": {
@@ -2098,13 +2100,13 @@
             },
             "strip-json-comments": {
               "version": "2.0.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
               "optional": true
             },
             "tar": {
               "version": "4.4.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-O+v1r9yN4tOsvl90p5HAP4AEqbYhx4036AGMm075fH9F8Qwi3oJ+v4u50FkT/KkvywNGtwkk0zRI+8eYm1X/xg==",
               "optional": true,
               "requires": {
@@ -2119,13 +2121,13 @@
             },
             "util-deprecate": {
               "version": "1.0.2",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
               "optional": true
             },
             "wide-align": {
               "version": "1.1.2",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
               "optional": true,
               "requires": {
@@ -2134,13 +2136,13 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
               "optional": true
             },
             "yallist": {
               "version": "3.0.2",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
               "optional": true
             }
@@ -4711,7 +4713,8 @@
     "has-symbol-support-x": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.1.tgz",
-      "integrity": "sha512-JkaetveU7hFbqnAC1EV1sF4rlojU2D4Usc5CmS69l6NfmPDnpnFUegzFg33eDkkpNCxZ0mQp65HwUDrNFS/8MA=="
+      "integrity": "sha512-JkaetveU7hFbqnAC1EV1sF4rlojU2D4Usc5CmS69l6NfmPDnpnFUegzFg33eDkkpNCxZ0mQp65HwUDrNFS/8MA==",
+      "optional": true
     },
     "has-symbols": {
       "version": "1.0.0",
@@ -4722,6 +4725,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
       "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
+      "optional": true,
       "requires": {
         "has-symbol-support-x": "^1.4.1"
       }
@@ -5266,6 +5270,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-falsey-x/-/is-falsey-x-1.0.1.tgz",
       "integrity": "sha512-XWNZC4A+3FX1ECoMjspuEFgSdio82IWjqY/suE0gZ10QA7nzHd/KraRq7Tc5VEHtFRgTRyTdY6W+ykPrDnyoAQ==",
+      "optional": true,
       "requires": {
         "to-boolean-x": "^1.0.1"
       }
@@ -5305,6 +5310,7 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/is-function-x/-/is-function-x-3.3.0.tgz",
       "integrity": "sha512-SreSSU1dlgYaXR5c0mm4qJHKYHIiGiEY+7Cd8/aRLLoMP/VvofD2XcWgBnP833ajpU5XzXbUSpfysnfKZLJFlg==",
+      "optional": true,
       "requires": {
         "attempt-x": "^1.1.1",
         "has-to-string-tag-x": "^1.4.1",
@@ -5369,12 +5375,14 @@
     "is-nan-x": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-nan-x/-/is-nan-x-1.0.3.tgz",
-      "integrity": "sha512-WenNBLVGSZID8shogsB++42vF7gvotCfneXM9KMCAKwNPXa8VfAu/RWwpqvnK7dLOP4Z7uitocb0TZ6rAiOccA=="
+      "integrity": "sha512-WenNBLVGSZID8shogsB++42vF7gvotCfneXM9KMCAKwNPXa8VfAu/RWwpqvnK7dLOP4Z7uitocb0TZ6rAiOccA==",
+      "optional": true
     },
     "is-nil-x": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/is-nil-x/-/is-nil-x-1.4.2.tgz",
       "integrity": "sha512-9aDY7ir7IGb5HlgqL+b38v2YMxf8S7MEHHxjHGzUhijg2crq47RKdxL37bS6dU0VN87wy2IBZP4akgQtIXmyvg==",
+      "optional": true,
       "requires": {
         "lodash.isnull": "^3.0.0",
         "validate.io-undefined": "^1.0.3"
@@ -5452,7 +5460,8 @@
     "is-primitive": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
+      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+      "optional": true
     },
     "is-promise": {
       "version": "2.1.0",
@@ -5887,7 +5896,8 @@
     "lodash.isnull": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash.isnull/-/lodash.isnull-3.0.0.tgz",
-      "integrity": "sha1-+vvlnqHcon7teGU0A53YTC4HxW4="
+      "integrity": "sha1-+vvlnqHcon7teGU0A53YTC4HxW4=",
+      "optional": true
     },
     "lodash.merge": {
       "version": "4.6.1",
@@ -6428,12 +6438,14 @@
     "nan": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.0.tgz",
-      "integrity": "sha512-F4miItu2rGnV2ySkXOQoA8FKz/SR2Q2sWP0sbTxNxz/tuokeC8WxOhPMcwi0qIyGtVn/rrSeLbvVkznqCdwYnw=="
+      "integrity": "sha512-F4miItu2rGnV2ySkXOQoA8FKz/SR2Q2sWP0sbTxNxz/tuokeC8WxOhPMcwi0qIyGtVn/rrSeLbvVkznqCdwYnw==",
+      "optional": true
     },
     "nan-x": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/nan-x/-/nan-x-1.0.2.tgz",
-      "integrity": "sha512-dndRmy03JQEN+Nh6WjQl7/OstIozeEmrtWe4TE7mEqJ8W8oMD8m2tHjsLPWt//e3hLAeRSbs4pxMyc5pk/nCkQ=="
+      "integrity": "sha512-dndRmy03JQEN+Nh6WjQl7/OstIozeEmrtWe4TE7mEqJ8W8oMD8m2tHjsLPWt//e3hLAeRSbs4pxMyc5pk/nCkQ==",
+      "optional": true
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -6624,6 +6636,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-space-x/-/normalize-space-x-3.0.0.tgz",
       "integrity": "sha512-tbCJerqZCCHPst4rRKgsTanLf45fjOyeAU5zE3mhDxJtFJKt66q39g2XArWhXelgTFVib8mNBUm6Wrd0LxYcfQ==",
+      "optional": true,
       "requires": {
         "cached-constructors-x": "^1.0.0",
         "trim-x": "^3.0.0",
@@ -6973,6 +6986,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/parse-int-x/-/parse-int-x-2.0.0.tgz",
       "integrity": "sha512-NIMm52gmd1+0qxJK8lV3OZ4zzWpRH1xcz9xCHXl+DNzddwUdS4NEtd7BmTeK7iCIXoaK5e6BoDMHgieH2eNIhg==",
+      "optional": true,
       "requires": {
         "cached-constructors-x": "^1.0.0",
         "nan-x": "^1.0.0",
@@ -7054,7 +7068,8 @@
     "path-key": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-1.0.0.tgz",
-      "integrity": "sha1-XVPVeAGWRsDWiADbThRua9wqx68="
+      "integrity": "sha1-XVPVeAGWRsDWiADbThRua9wqx68=",
+      "optional": true
     },
     "path-parse": {
       "version": "1.0.6",
@@ -7844,6 +7859,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/replace-comments-x/-/replace-comments-x-2.0.0.tgz",
       "integrity": "sha512-+vMP4jqU+8HboLWms6YMNEiaZG5hh1oR6ENCnGYDF/UQ7aYiJUK/8tcl3+KZAHRCKKa3gqzrfiarlUBHQSgRlg==",
+      "optional": true,
       "requires": {
         "require-coercible-to-string-x": "^1.0.0",
         "to-string-x": "^1.4.2"
@@ -7910,6 +7926,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/require-coercible-to-string-x/-/require-coercible-to-string-x-1.0.0.tgz",
       "integrity": "sha512-Rpfd4sMdflPAKecdKhfAtQHlZzzle4UMUgxJ01hXtTcNWMV8w9GeZnKhEyrT73kgrflBOP1zg41amUPZGcNspA==",
+      "optional": true,
       "requires": {
         "require-object-coercible-x": "^1.4.1",
         "to-string-x": "^1.4.2"
@@ -7931,6 +7948,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/require-object-coercible-x/-/require-object-coercible-x-1.4.1.tgz",
       "integrity": "sha512-0YHa2afepsLfQvwQ1P2XvDZnGOUia5sC07ZijIRU2dnsRxnuilXWF6B2CFaKGDA9eZl39lJHrXCDsnfgroRd6Q==",
+      "optional": true,
       "requires": {
         "is-nil-x": "^1.4.1"
       }
@@ -9415,7 +9433,8 @@
     "to-boolean-x": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/to-boolean-x/-/to-boolean-x-1.0.1.tgz",
-      "integrity": "sha512-PstxY3K6hVEHnY3FITs8XBoJbt0RI1e4MLIhAL9hWa3BtVLCrb86vU5z6lEKh7uZZjiPiLqIKMmfMro1nNgtXQ=="
+      "integrity": "sha512-PstxY3K6hVEHnY3FITs8XBoJbt0RI1e4MLIhAL9hWa3BtVLCrb86vU5z6lEKh7uZZjiPiLqIKMmfMro1nNgtXQ==",
+      "optional": true
     },
     "to-buffer": {
       "version": "1.1.1",
@@ -9445,6 +9464,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-2.0.0.tgz",
       "integrity": "sha512-lGOnCoccUoSzjZ/9Uen8TC4+VFaQcFGhTroWTv2tYWxXgyJV1zqAZ8hEIMkez/Eo790fBMOjidTnQ/OJSCvAoQ==",
+      "optional": true,
       "requires": {
         "cached-constructors-x": "^1.0.0",
         "nan-x": "^1.0.0",
@@ -9465,6 +9485,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/to-object-x/-/to-object-x-1.5.0.tgz",
       "integrity": "sha512-AKn5GQcdWky+s20vjWkt+Wa6y3dxQH3yQyMBhOfBOPldUwqwhgvlqcIg5H092ntNc+TX8/Cxzs1kMHH19pyCnA==",
+      "optional": true,
       "requires": {
         "cached-constructors-x": "^1.0.0",
         "require-object-coercible-x": "^1.4.1"
@@ -9474,6 +9495,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/to-primitive-x/-/to-primitive-x-1.1.0.tgz",
       "integrity": "sha512-gyMY0gi3wjK3e4MUBKqv9Zl8QGcWguIkaUr2VJmoBEsOpDcpDZSEyljR773eVG4maS48uX7muLkoQoh/BA82OQ==",
+      "optional": true,
       "requires": {
         "has-symbol-support-x": "^1.4.1",
         "is-date-object": "^1.0.1",
@@ -9489,6 +9511,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/to-property-key-x/-/to-property-key-x-2.0.2.tgz",
       "integrity": "sha512-YISLpZFYIazNm0P8hLsKEEUEZ3m8U3+eDysJZqTu3+B9tQp+2TrMpaEGT8Agh4fZ5LSoums60/glNEzk5ozqrg==",
+      "optional": true,
       "requires": {
         "has-symbol-support-x": "^1.4.1",
         "to-primitive-x": "^1.1.0",
@@ -9590,6 +9613,7 @@
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/to-string-tag-x/-/to-string-tag-x-1.4.2.tgz",
       "integrity": "sha512-ytO9eLigxsQQLGuab0C1iSSTzKdJNVSlBg0Spg4J/rGAVrQJ5y774mo0SSzgGeTT4RJGGyJNfObXaTMzX0XDOQ==",
+      "optional": true,
       "requires": {
         "lodash.isnull": "^3.0.0",
         "validate.io-undefined": "^1.0.3"
@@ -9599,6 +9623,7 @@
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/to-string-x/-/to-string-x-1.4.5.tgz",
       "integrity": "sha512-5xzlZDyDa9BUWNjNzZzHgKQ95PnV7qjvEhbqpFaj1ixaHgfJXOFaa3xdMJ+WLYd4hhaMJaxt8Pt5uKaWXfruXA==",
+      "optional": true,
       "requires": {
         "cached-constructors-x": "^1.0.0",
         "is-symbol": "^1.0.1"
@@ -9692,6 +9717,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/trim-left-x/-/trim-left-x-3.0.0.tgz",
       "integrity": "sha512-+m6cqkppI+CxQBTwWEZliOHpOBnCArGyMnS1WCLb6IRgukhTkiQu/TNEN5Lj2eM9jk8ewJsc7WxFZfmwNpRXWQ==",
+      "optional": true,
       "requires": {
         "cached-constructors-x": "^1.0.0",
         "require-coercible-to-string-x": "^1.0.0",
@@ -9713,6 +9739,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/trim-right-x/-/trim-right-x-3.0.0.tgz",
       "integrity": "sha512-iIqEsWEbWVodqdixJHi4FoayJkUxhoL4AvSNGp4FF4FfQKRPGizt8++/RnyC9od75y7P/S6EfONoVqP+NddiKA==",
+      "optional": true,
       "requires": {
         "cached-constructors-x": "^1.0.0",
         "require-coercible-to-string-x": "^1.0.0",
@@ -9723,6 +9750,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/trim-x/-/trim-x-3.0.0.tgz",
       "integrity": "sha512-w8s38RAUScQ6t3XqMkS75iz5ZkIYLQpVnv2lp3IuTS36JdlVzC54oe6okOf4Wz3UH4rr3XAb2xR3kR5Xei82fw==",
+      "optional": true,
       "requires": {
         "trim-left-x": "^3.0.0",
         "trim-right-x": "^3.0.0"
@@ -10240,7 +10268,8 @@
     "validate.io-undefined": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/validate.io-undefined/-/validate.io-undefined-1.0.3.tgz",
-      "integrity": "sha1-fif8uzFbhB54JDQxiXZxkp4gt/Q="
+      "integrity": "sha1-fif8uzFbhB54JDQxiXZxkp4gt/Q=",
+      "optional": true
     },
     "validator": {
       "version": "9.1.2",
@@ -10627,7 +10656,8 @@
     "white-space-x": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/white-space-x/-/white-space-x-3.0.0.tgz",
-      "integrity": "sha512-nMPVXGMdi/jQepXKryxqzEh/vCwdOYY/u6NZy40glMHvZfEr7/+vQKnDhEq4rZ1nniOFq9GWohQYB30uW/5Olg=="
+      "integrity": "sha512-nMPVXGMdi/jQepXKryxqzEh/vCwdOYY/u6NZy40glMHvZfEr7/+vQKnDhEq4rZ1nniOFq9GWohQYB30uW/5Olg==",
+      "optional": true
     },
     "wide-align": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "location-history": "^1.0.0",
     "material-ui": "^0.20.2",
     "mkdirp": "^0.5.1",
-    "music-metadata": "^3.5.2",
+    "music-metadata": "^3.6.1",
     "network-address": "^1.1.0",
     "parse-torrent": "^6.0.1",
     "prettier-bytes": "^1.0.1",

--- a/src/renderer/lib/media-extensions.js
+++ b/src/renderer/lib/media-extensions.js
@@ -1,8 +1,8 @@
 const mediaExtensions = {
   audio: [
-    '.aac', 'aif', 'aiff', '.asf', '.flac', '.m2a', '.m4a', '.m4b',
-    '.mp2', '.mp3', '.mpc', '.oga', '.ogg', '.opus', 'spx', '.wma',
-    '.wav', '.wv', '.wvp'],
+    '.aac', 'aif', 'aiff', '.asf', '.dff', '.dsf', '.flac', '.m2a',
+    '.m4a', '.m4b', '.mp2', '.mp3', '.mpc', '.oga', '.ogg', '.opus',
+    'spx', '.wma', '.wav', '.wv', '.wvp'],
   video: [
     '.avi', '.mp4', '.m4v', '.webm', '.mov', '.mkv', 'mpg', 'mpeg',
     '.ogv', '.webm', '.wmv'],


### PR DESCRIPTION
1. Update music-metadata to [v3.6.1](https://github.com/Borewit/music-metadata/tree/v3.6.1)
2. Register [DSD](https://en.wikipedia.org/wiki/Direct_Stream_Digital) types as audio media extensions:
   1.  Philips DSDIFF (.dff) DSD files
   2. Sony .dsf (DSD Stream File) format

This update PR aims to:
1. Keep music-metadata up to date 
2. Recognize [DSD audio](https://en.wikipedia.org/wiki/Direct_Stream_Digital) torrents (& ability to read it's metadata)

In order to successfully pass DSD audio streams to VLC.
It maybe required set MIME-type to make VLC understand the audio format.
As far as I know there are no MIME-type defined for DSDIFF & DSF, at most some unofficial conventions.