### PR TITLE
Add YouTube style hotkeys. Closes #1395

### DIFF
--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -147,6 +147,9 @@ function onState (err, _state) {
   // ...same thing if you paste a torrent
   document.addEventListener('paste', onPaste)
 
+  // Add YouTube style hotkey shortcuts
+  window.addEventListener('keydown', onKeydown)
+
   const debouncedFullscreenToggle = debounce(function () {
     dispatch('toggleFullScreen')
   }, 1000, true)
@@ -503,6 +506,32 @@ const editableHtmlTags = new Set(['input', 'textarea'])
 function onPaste (e) {
   if (editableHtmlTags.has(e.target.tagName.toLowerCase())) return
   controllers.torrentList().addTorrent(electron.clipboard.readText())
+
+  update()
+}
+
+function onKeydown (e) {
+  const key = e.key
+
+  if (key === 'ArrowLeft') {
+    dispatch('skip', -5)
+  } else if (key === 'ArrowRight') {
+    dispatch('skip', 5)
+  } else if (key === 'ArrowUp') {
+    dispatch('changeVolume', 0.1)
+  } else if (key === 'ArrowDown') {
+    dispatch('changeVolume', -0.1)
+  } else if (key === 'j') {
+    dispatch('skip', -10)
+  } else if (key === 'l') {
+    dispatch('skip', 10)
+  } else if (key === 'k') {
+    dispatch('playPause')
+  } else if (key === '>') {
+    dispatch('changePlaybackRate', 1)
+  } else if (key === '<') {
+    dispatch('changePlaybackRate', -1)
+  }
 
   update()
 }

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -531,6 +531,8 @@ function onKeydown (e) {
     dispatch('changePlaybackRate', 1)
   } else if (key === '<') {
     dispatch('changePlaybackRate', -1)
+  } else if (key === 'f') {
+    dispatch('toggleFullScreen')
   }
 
   update()


### PR DESCRIPTION
This is a continuation of PR https://github.com/webtorrent/webtorrent-desktop/pull/1443, which appears abandoned. 

Props to @hicom150 for starting that. I would have added commits on top of that, to preserve git history etc, but the underlying branch looks deleted 😕

This PR takes into account the code changes requested by @mathiasvr in https://github.com/webtorrent/webtorrent-desktop/pull/1443#issuecomment-429120108

> I would request the following changes:
> 
> * use keydown instead of keyup, i think instant feedback and repeated events is an improvement.
> * use window.addEventListener instead of document.addEventListener.
> * use e.key instead e.code, currently this PR only works with qwerty keyboard layouts.

All of these have been included. 

👍 This PR has been tested to work locally on macOS 10.14.4.

----

This closes the original feature request by @feross in https://github.com/webtorrent/webtorrent-desktop/issues/1395.