### PR TITLE
Remove old hotkeys in favor of new YouTube style

### DIFF
--- a/src/main/menu.js
+++ b/src/main/menu.js
@@ -224,13 +224,13 @@ function getMenuTemplate () {
         },
         {
           label: 'Increase Volume',
-          accelerator: 'CmdOrCtrl+Up',
+          accelerator: 'Up',
           click: () => windows.main.dispatch('changeVolume', 0.1),
           enabled: false
         },
         {
           label: 'Decrease Volume',
-          accelerator: 'CmdOrCtrl+Down',
+          accelerator: 'Down',
           click: () => windows.main.dispatch('changeVolume', -0.1),
           enabled: false
         },
@@ -239,18 +239,14 @@ function getMenuTemplate () {
         },
         {
           label: 'Step Forward',
-          accelerator: process.platform === 'darwin'
-            ? 'CmdOrCtrl+Alt+Right'
-            : 'Alt+Right',
-          click: () => windows.main.dispatch('skip', 10),
+          accelerator: 'Right',
+          click: () => windows.main.dispatch('skip', 5),
           enabled: false
         },
         {
           label: 'Step Backward',
-          accelerator: process.platform === 'darwin'
-            ? 'CmdOrCtrl+Alt+Left'
-            : 'Alt+Left',
-          click: () => windows.main.dispatch('skip', -10),
+          accelerator: 'Left',
+          click: () => windows.main.dispatch('skip', -5),
           enabled: false
         },
         {
@@ -258,13 +254,13 @@ function getMenuTemplate () {
         },
         {
           label: 'Increase Speed',
-          accelerator: 'CmdOrCtrl+=',
+          accelerator: '>',
           click: () => windows.main.dispatch('changePlaybackRate', 1),
           enabled: false
         },
         {
           label: 'Decrease Speed',
-          accelerator: 'CmdOrCtrl+-',
+          accelerator: '<',
           click: () => windows.main.dispatch('changePlaybackRate', -1),
           enabled: false
         },

--- a/src/main/menu.js
+++ b/src/main/menu.js
@@ -153,9 +153,7 @@ function getMenuTemplate () {
         {
           label: 'Full Screen',
           type: 'checkbox',
-          accelerator: process.platform === 'darwin'
-            ? 'Ctrl+Command+F'
-            : 'F11',
+          accelerator: 'F',
           click: () => windows.main.toggleFullScreen()
         },
         {

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -147,9 +147,6 @@ function onState (err, _state) {
   // ...same thing if you paste a torrent
   document.addEventListener('paste', onPaste)
 
-  // Add YouTube style hotkey shortcuts
-  window.addEventListener('keydown', onKeydown)
-
   const debouncedFullscreenToggle = debounce(function () {
     dispatch('toggleFullScreen')
   }, 1000, true)
@@ -506,34 +503,6 @@ const editableHtmlTags = new Set(['input', 'textarea'])
 function onPaste (e) {
   if (editableHtmlTags.has(e.target.tagName.toLowerCase())) return
   controllers.torrentList().addTorrent(electron.clipboard.readText())
-
-  update()
-}
-
-function onKeydown (e) {
-  const key = e.key
-
-  if (key === 'ArrowLeft') {
-    dispatch('skip', -5)
-  } else if (key === 'ArrowRight') {
-    dispatch('skip', 5)
-  } else if (key === 'ArrowUp') {
-    dispatch('changeVolume', 0.1)
-  } else if (key === 'ArrowDown') {
-    dispatch('changeVolume', -0.1)
-  } else if (key === 'j') {
-    dispatch('skip', -10)
-  } else if (key === 'l') {
-    dispatch('skip', 10)
-  } else if (key === 'k') {
-    dispatch('playPause')
-  } else if (key === '>') {
-    dispatch('changePlaybackRate', 1)
-  } else if (key === '<') {
-    dispatch('changePlaybackRate', -1)
-  } else if (key === 'f') {
-    dispatch('toggleFullScreen')
-  }
 
   update()
 }


### PR DESCRIPTION
This is a follow on to the discussions in https://github.com/webtorrent/webtorrent-desktop/pull/1579 and https://github.com/webtorrent/webtorrent-desktop/pull/1443.

The unresolved question was **whether it's better to have both the old hotkeys as well as the new ones, or to simply replace the old with the new.** 

#1579 was merged in to add both. This PR would remove the old hotkeys to only have the new ones.

![image](https://user-images.githubusercontent.com/6340841/57259173-7b7d2780-7013-11e9-904b-9c6074f561b5.png)


Currently these new hotkeys are undocumented.


-----

👍 This PR has been tested to work locally on macOS 10.14.4.