### PR TITLE
Fix hiddenInset (Mac) titlebar style for electron 4

### DIFF
--- a/src/main/windows/main.js
+++ b/src/main/windows/main.js
@@ -40,7 +40,7 @@ function init (state, options) {
     minWidth: config.WINDOW_MIN_WIDTH,
     show: false,
     title: config.APP_WINDOW_TITLE,
-    titleBarStyle: 'hidden-inset', // Hide title bar (Mac)
+    titleBarStyle: 'hiddenInset', // Hide title bar (Mac)
     useContentSize: true, // Specify web page size without OS chrome
     width: initialBounds.width,
     x: initialBounds.x,


### PR DESCRIPTION
This fixes bugginess w/ a duplicated title bar on macOS, as part of the upgrade to Electron 4 (https://github.com/webtorrent/webtorrent-desktop/pull/1590):

### Before:

![image](https://user-images.githubusercontent.com/6340841/58848968-58a75880-863d-11e9-8258-9404c8802637.png)

### After:

![image](https://user-images.githubusercontent.com/6340841/58849226-732e0180-863e-11e9-886b-ad9930ef0771.png)

----

Docs about this param: https://electronjs.org/docs/api/frameless-window#hiddeninset 

Note about this breaking change introduced in Electron 2.0: https://github.com/electron/electron/blob/master/docs/api/breaking-changes.md#browserwindow-1

> <img src="https://user-images.githubusercontent.com/6340841/58850034-90180400-8641-11e9-9f0e-964e6a2aee22.png" width="550px" />
