### PR TITLE
Electron 4: Migrate .openDevTools() for new 'detach' pattern

### DIFF
--- a/src/main/windows/main.js
+++ b/src/main/windows/main.js
@@ -209,7 +209,7 @@ function toggleDevTools () {
   if (main.win.webContents.isDevToolsOpened()) {
     main.win.webContents.closeDevTools()
   } else {
-    main.win.webContents.openDevTools({ detach: true })
+    main.win.webContents.openDevTools({ mode: 'detach' })
   }
 }
 

--- a/src/main/windows/webtorrent.js
+++ b/src/main/windows/webtorrent.js
@@ -56,6 +56,6 @@ function toggleDevTools () {
     webtorrent.win.webContents.closeDevTools()
     webtorrent.win.hide()
   } else {
-    webtorrent.win.webContents.openDevTools({ detach: true })
+    webtorrent.win.webContents.openDevTools({ mode: 'detach' })
   }
 }


### PR DESCRIPTION
#### Part of Electron 4 upgrade (PR https://github.com/webtorrent/webtorrent-desktop/pull/1590)

-------

This updates the invocations of `.openDevTools()` to match the new `detach` pattern required by Electron 3.0 (described in [Breaking Changes doc](https://github.com/electron/electron/blob/master/docs/api/breaking-changes.md#webcontents)):

<img src="https://user-images.githubusercontent.com/6340841/58852113-25b79180-864a-11e9-9fe3-8dc5f5df4daf.png" width="550px" />

-------

Tested to work on MacOS 👍 
