### PR TITLE
Update music-metadata to version 4.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2437,6 +2437,11 @@
       "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
       "dev": true
     },
+    "content-type": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+    },
     "copy-descriptor": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
@@ -4107,9 +4112,9 @@
       }
     },
     "file-type": {
-      "version": "10.11.0",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-10.11.0.tgz",
-      "integrity": "sha512-uzk64HRpUZyTGZtVuvrjP0FYxzQrBf4rojot6J65YMEbwBLB0CWm0CLojVpwpmFmxcE/lkvYICgfcGozbBq6rw=="
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-11.1.0.tgz",
+      "integrity": "sha512-rM0UO7Qm9K7TWTtA6AShI/t7H5BPjDeGVDaNyg9BjHAj3PysKy7+8C8D137R88jnR3rFJZQB/tFgydl5sN5m7g=="
     },
     "filestream": {
       "version": "4.1.3",
@@ -6169,9 +6174,9 @@
       "optional": true
     },
     "media-typer": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="
     },
     "mediasource": {
       "version": "2.2.2",
@@ -6496,14 +6501,15 @@
       }
     },
     "music-metadata": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/music-metadata/-/music-metadata-3.6.1.tgz",
-      "integrity": "sha512-lPp5g64NdpX4ZVLopt5ZdNXkefhrfJGqzNuAtDPMUs9NrRzn7MAvHqMFrhefpmyvEEUcptDaQMRUMupnugdKmw==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/music-metadata/-/music-metadata-4.1.1.tgz",
+      "integrity": "sha512-ekn02J07IdUth8IrYr+rSXAg0joZe6kF+4d0zq9eN+FPFBbohW9XDoHEFWyJ6gO0ciUxSfpglxlc+Y8qhQ3J8Q==",
       "requires": {
+        "content-type": "^1.0.4",
         "debug": "^4.1.0",
-        "file-type": "^10.5.0",
-        "media-typer": "0.3.0",
-        "strtok3": "^2.3.0",
+        "file-type": "^11.0.0",
+        "media-typer": "^1.1.0",
+        "strtok3": "^3.0.0",
         "token-types": "^1.0.1"
       },
       "dependencies": {
@@ -6516,9 +6522,9 @@
           }
         },
         "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },
@@ -9285,12 +9291,12 @@
       "dev": true
     },
     "strtok3": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-2.3.0.tgz",
-      "integrity": "sha512-AA67/1atBh7X0fUTDevjW89by2ZkY9RZAnkwusx5Yc1COYf0ruUbpYOOIs03SnRA1CF9K3+BtRXKOEtKhAXVaQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-3.0.0.tgz",
+      "integrity": "sha512-Sm17gVuapi4jR5cE6UnYhstZ7jGeH9a/eM7Sbg5IDk6bw3Z7FF0UTA1tnZo2Gt7OmY+/O9kVAnAGJ9mglvf36w==",
       "requires": {
-        "debug": "^4.1.0",
-        "then-read-stream": "^1.5.0",
+        "debug": "^4.1.1",
+        "then-read-stream": "^2.0.0",
         "token-types": "^1.0.1"
       },
       "dependencies": {
@@ -9303,9 +9309,9 @@
           }
         },
         "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },
@@ -9566,9 +9572,9 @@
       "dev": true
     },
     "then-read-stream": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/then-read-stream/-/then-read-stream-1.5.0.tgz",
-      "integrity": "sha512-Qu+Dp3G28GBmewssIjoRwcmdnsymjdSFt17s8qAajQKesBjLoRAj3VgWftiLSC5CJV6PEYOS0d45WGTJp8QFxQ=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/then-read-stream/-/then-read-stream-2.0.0.tgz",
+      "integrity": "sha512-mdQRdZ+71UVL9H6y2bRt/SlpIgzi223LEx8gxbRCfVURnXrokMYo1w+jNcATTZLR25kVUb+h8X6BlmoW4173fQ=="
     },
     "thirty-two": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "location-history": "^1.0.0",
     "material-ui": "^0.20.2",
     "mkdirp": "^0.5.1",
-    "music-metadata": "^3.6.1",
+    "music-metadata": "^4.1.1",
     "network-address": "^1.1.0",
     "parse-torrent": "^6.0.1",
     "prettier-bytes": "^1.0.1",

--- a/src/renderer/pages/player-page.js
+++ b/src/renderer/pages/player-page.js
@@ -301,14 +301,18 @@ function renderAudioMetadata (state) {
   // Audio metadata: format
   const format = []
   fileSummary.audioInfo.format = fileSummary.audioInfo.format || ''
-  if (fileSummary.audioInfo.format.dataformat) {
-    format.push(fileSummary.audioInfo.format.dataformat)
+  if (fileSummary.audioInfo.format.container) {
+    format.push(fileSummary.audioInfo.format.container)
+  }
+  if (fileSummary.audioInfo.format.codec &&
+    fileSummary.audioInfo.format.container !== fileSummary.audioInfo.format.codec) {
+    format.push(fileSummary.audioInfo.format.codec)
   }
   if (fileSummary.audioInfo.format.bitrate) {
     format.push(Math.round(fileSummary.audioInfo.format.bitrate / 1000) + ' kbps') // 128 kbps
   }
   if (fileSummary.audioInfo.format.sampleRate) {
-    format.push(Math.round(fileSummary.audioInfo.format.sampleRate / 100) / 10 + ' kHz') // 44.1 kHz
+    format.push(Math.round(fileSummary.audioInfo.format.sampleRate / 100) / 10 + ' kHz')
   }
   if (fileSummary.audioInfo.format.bitsPerSample) {
     format.push(fileSummary.audioInfo.format.bitsPerSample + ' bit')


### PR DESCRIPTION
- Update music-metadata to version [~~4.1.1~~](https://github.com/Borewit/music-metadata/releases/tag/v4.1.1) [4.2.0](https://github.com/Borewit/music-metadata/releases/tag/v4.2.0)
- Adapt to it's API changes: `format.dataformat` replaced by `format.container` & `format.codec`