### PR TITLE
Update to Electron 6

### DIFF
--- a/bin/extra-lint.js
+++ b/bin/extra-lint.js
@@ -18,13 +18,6 @@ files.forEach(function (file) {
   lines.forEach(function (line, i) {
     let error
 
-    // Consistent JSX tag closing
-    if (line.match(/' {2}\/> *$/) ||
-      line.match('[^ ]/> *$') ||
-      line.match(' > *$')) {
-      error = 'JSX tag spacing'
-    }
-
     // No lines over 100 characters
     if (line.length > 100) {
       error = 'Line >100 chars'

--- a/package-lock.json
+++ b/package-lock.json
@@ -2614,9 +2614,9 @@
       "dev": true
     },
     "electron": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-4.2.8.tgz",
-      "integrity": "sha512-/D9zfs+EWLN4yLV7tu2kWyXUnZQ3CKG1cmWbXeSFXF+0dNXQ8iFpY49dqZRoHGIBImFfp2x4N3Zc5Tu7rw3PJw==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-5.0.9.tgz",
+      "integrity": "sha512-yCt+lnQr47OWB3Oei19odMVB8VKzecTwZLm75PB56f/keeJAM3UqV7+dtjKlPdKt0hJ4sWxe4vjxGPO/oZDv7A==",
       "dev": true,
       "requires": {
         "@types/node": "^10.12.18",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2614,9 +2614,9 @@
       "dev": true
     },
     "electron": {
-      "version": "5.0.9",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-5.0.9.tgz",
-      "integrity": "sha512-yCt+lnQr47OWB3Oei19odMVB8VKzecTwZLm75PB56f/keeJAM3UqV7+dtjKlPdKt0hJ4sWxe4vjxGPO/oZDv7A==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-6.0.1.tgz",
+      "integrity": "sha512-XY69rI5IThIxsOS2BD+1ZkHE9hqkm4xN5a3WQFSmFRr2by4q5CnIe9vXmptlouGPTLs3tb7ySX/+K9CvH3szvg==",
       "dev": true,
       "requires": {
         "@types/node": "^10.12.18",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "buble": "^0.19.6",
     "cross-zip": "^2.0.1",
     "depcheck": "^0.8.0",
-    "electron": "~5.0.9",
+    "electron": "~6.0.1",
     "electron-osx-sign": "^0.4.11",
     "electron-packager": "^14.0.4",
     "electron-winstaller": "^2.6.4",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "buble": "^0.19.6",
     "cross-zip": "^2.0.1",
     "depcheck": "^0.8.0",
-    "electron": "^4.0.0",
+    "electron": "~5.0.9",
     "electron-osx-sign": "^0.4.11",
     "electron-packager": "^14.0.4",
     "electron-winstaller": "^2.6.4",

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -13,6 +13,8 @@ const menu = require('./menu')
 const State = require('../renderer/lib/state')
 const windows = require('./windows')
 
+const WEBTORRENT_VERSION = require('webtorrent/package.json').version
+
 let shouldQuit = false
 let argv = sliceArgv(process.argv)
 
@@ -95,6 +97,12 @@ function init () {
       windows.main.dispatch('uncaughtError', 'main', error)
     })
   }
+
+  // Enable app logging into default directory, i.e. /Library/Logs/WebTorrent
+  // on Mac, %APPDATA% on Windows, $XDG_CONFIG_HOME or ~/.config on Linux.
+  app.setAppLogsPath()
+
+  app.userAgentFallback = `WebTorrent/${WEBTORRENT_VERSION} (https://webtorrent.io)`
 
   app.on('open-file', onOpen)
   app.on('open-url', onOpen)

--- a/src/main/windows/about.js
+++ b/src/main/windows/about.js
@@ -24,6 +24,9 @@ function init () {
     skipTaskbar: true,
     title: 'About ' + config.APP_WINDOW_TITLE,
     useContentSize: true,
+    webPreferences: {
+      nodeIntegration: true
+    },
     width: 300
   })
 

--- a/src/main/windows/main.js
+++ b/src/main/windows/main.js
@@ -43,6 +43,9 @@ function init (state, options) {
     titleBarStyle: 'hiddenInset', // Hide title bar (Mac)
     useContentSize: true, // Specify web page size without OS chrome
     width: initialBounds.width,
+    webPreferences: {
+      nodeIntegration: true
+    },
     x: initialBounds.x,
     y: initialBounds.y
   })

--- a/src/main/windows/webtorrent.js
+++ b/src/main/windows/webtorrent.js
@@ -25,6 +25,9 @@ function init () {
     skipTaskbar: true,
     title: 'webtorrent-hidden-window',
     useContentSize: true,
+    webPreferences: {
+      nodeIntegration: true
+    },
     width: 150
   })
 

--- a/src/renderer/lib/telemetry.js
+++ b/src/renderer/lib/telemetry.js
@@ -74,7 +74,7 @@ function reset () {
 
 // Track screen resolution
 function getScreenInfo () {
-  return electron.screen.getAllDisplays().map((screen) => ({
+  return electron.remote.screen.getAllDisplays().map((screen) => ({
     width: screen.size.width,
     height: screen.size.height,
     scaleFactor: screen.scaleFactor

--- a/src/renderer/pages/player-page.js
+++ b/src/renderer/pages/player-page.js
@@ -117,8 +117,6 @@ function renderMedia (state) {
     }
   }
 
-  console.log('rendering src', Playlist.getCurrentLocalURL(state))
-
   // Create the <audio> or <video> tag
   const MediaTagName = state.playing.type
   const mediaTag = (

--- a/src/renderer/pages/player-page.js
+++ b/src/renderer/pages/player-page.js
@@ -1,3 +1,5 @@
+/* global HTMLMediaElement */
+
 const React = require('react')
 const Bitfield = require('bitfield')
 const prettyBytes = require('prettier-bytes')
@@ -115,6 +117,8 @@ function renderMedia (state) {
     }
   }
 
+  console.log('rendering src', Playlist.getCurrentLocalURL(state))
+
   // Create the <audio> or <video> tag
   const MediaTagName = state.playing.type
   const mediaTag = (
@@ -127,7 +131,8 @@ function renderMedia (state) {
       onError={dispatcher('mediaError')}
       onTimeUpdate={dispatcher('mediaTimeUpdate')}
       onEncrypted={dispatcher('mediaEncrypted')}
-      onCanPlay={onCanPlay}>
+      onCanPlay={onCanPlay}
+    >
       {trackTags}
     </MediaTagName>
   )
@@ -166,6 +171,7 @@ function renderMedia (state) {
 
   function onCanPlay (e) {
     const elem = e.target
+    if (elem.readyState < HTMLMediaElement.HAVE_FUTURE_DATA) return
     if (state.playing.type === 'video' &&
       elem.webkitVideoDecodedByteCount === 0) {
       dispatch('mediaError', 'Video codec unsupported')


### PR DESCRIPTION
~~DO NOT MERGE.~~ Ready to merge!

There seems to be an issue with the media codecs in this version of Electron. Sintel and the WIRED CD do not play back directly in Electron anymore. Instead, VLC is recommended. We need to dig into this problem to figure out if the problem is on our end or on Electron's. If it's Electron, we need to file an issue.