### PR TITLE
Fix uninstall handlers in Linux

### DIFF
--- a/src/main/handlers.js
+++ b/src/main/handlers.js
@@ -355,7 +355,7 @@ function uninstallLinux () {
     'applications',
     'webtorrent-desktop.desktop'
   )
-  rimraf(desktopFilePath)
+  rimraf.sync(desktopFilePath)
 
   const iconFilePath = path.join(
     os.homedir(),
@@ -364,5 +364,5 @@ function uninstallLinux () {
     'icons',
     'webtorrent-desktop.png'
   )
-  rimraf(iconFilePath)
+  rimraf.sync(iconFilePath)
 }


### PR DESCRIPTION
As described in #1645 `npm run clean` fail in Linux as `rimraf` expects a callback to be defined unless we use the `.sync` method.

This PR fixes this issue.