### PR TITLE
Pass title metadata in media url

### DIFF
--- a/src/renderer/controllers/playback-controller.js
+++ b/src/renderer/controllers/playback-controller.js
@@ -269,6 +269,7 @@ module.exports = class PlaybackController {
     // update state
     state.playing.infoHash = infoHash
     state.playing.fileIndex = index
+    state.playing.fileName = fileSummary.name
     state.playing.type = TorrentPlayer.isVideo(fileSummary) ? 'video'
       : TorrentPlayer.isAudio(fileSummary) ? 'audio'
         : 'other'

--- a/src/renderer/lib/playlist.js
+++ b/src/renderer/lib/playlist.js
@@ -38,7 +38,7 @@ function getPreviousIndex (state) {
 
 function getCurrentLocalURL (state) {
   return state.server
-    ? state.server.localURL + '/' + state.playing.fileIndex + '/' + state.window.title
+    ? state.server.localURL + '/' + state.playing.fileIndex + '/' + encodeURIComponent(state.playing.fileName)
     : ''
 }
 

--- a/src/renderer/lib/playlist.js
+++ b/src/renderer/lib/playlist.js
@@ -38,7 +38,7 @@ function getPreviousIndex (state) {
 
 function getCurrentLocalURL (state) {
   return state.server
-    ? state.server.localURL + '/' + state.playing.fileIndex
+    ? state.server.localURL + '/' + state.playing.fileIndex + '/' + state.window.title
     : ''
 }
 


### PR DESCRIPTION
This is a small fix to show the file name when streaming content.

As @feross suggested in #1349 changing `mediaUrl` from `https://localhost:port/<file-index>` to `https://localhost:port/<file-index>/<file-name>` fixes the issue.