### PR TITLE
Fix path selector value when path is not defined

### DIFF
--- a/src/renderer/pages/preferences-page.js
+++ b/src/renderer/pages/preferences-page.js
@@ -105,7 +105,7 @@ class PreferencesPage extends React.Component {
           displayValue={playerName}
           onChange={this.handleExternalPlayerPathChange}
           title='External player'
-          value={playerPath ? path.dirname(playerPath) : null}
+          value={playerPath ? path.dirname(playerPath) : ''}
         />
       </Preference>
     )
@@ -159,7 +159,7 @@ class PreferencesPage extends React.Component {
           displayValue={torrentsFolderPath || ''}
           onChange={this.handleTorrentsFolderPathChange}
           title='Folder to watch'
-          value={torrentsFolderPath ? path.dirname(torrentsFolderPath) : null}
+          value={torrentsFolderPath ? path.dirname(torrentsFolderPath) : ''}
         />
       </Preference>
     )


### PR DESCRIPTION
In PathSelector component value is mapped to electron's `showOpenDialog` `defaultPath` property that should be a valid string.

In `preferences-page.js` in some cases that value was passed as `null` and causes an error in `showOpenDialog` preventing from displaying it.

This PR fixes the issue passing `''` as a default value when no there is no valid path.