### PR TITLE
Update dependency music-metadata to v4.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3665,9 +3665,9 @@
       }
     },
     "file-type": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-11.1.0.tgz",
-      "integrity": "sha512-rM0UO7Qm9K7TWTtA6AShI/t7H5BPjDeGVDaNyg9BjHAj3PysKy7+8C8D137R88jnR3rFJZQB/tFgydl5sN5m7g=="
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-12.2.0.tgz",
+      "integrity": "sha512-bkDBeH5doAqP69axEO69OviLlWbrZ10Ne2OPHaxBgG+fyT0w/2zfMzJz21SPwq5Iq0aN70q7RN3KRcdUY427Mg=="
     },
     "filestream": {
       "version": "5.0.0",
@@ -5938,13 +5938,13 @@
       }
     },
     "music-metadata": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/music-metadata/-/music-metadata-4.2.1.tgz",
-      "integrity": "sha512-+82UydNm/EVoazeRR7YhRGHNNqbPXDsI0O7/2gyk+o+jrAVBZclEM33rdl6BbikEFpWTOxhZW3EZkVQtiGDeTg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/music-metadata/-/music-metadata-4.3.0.tgz",
+      "integrity": "sha512-3AkowwE+sdT/YqGOacbekPEQvMszzFHLJid1mVBAiOM9HPuPV7Wm+uej3SRYydhzaLJpZW+yPqGYpgz4BwrcuQ==",
       "requires": {
         "content-type": "^1.0.4",
         "debug": "^4.1.0",
-        "file-type": "^11.0.0",
+        "file-type": "^12.1.0",
         "media-typer": "^1.1.0",
         "strtok3": "^3.0.0",
         "token-types": "^1.0.1"
@@ -9102,11 +9102,6 @@
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        },
-        "then-read-stream": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/then-read-stream/-/then-read-stream-2.0.0.tgz",
-          "integrity": "sha512-mdQRdZ+71UVL9H6y2bRt/SlpIgzi223LEx8gxbRCfVURnXrokMYo1w+jNcATTZLR25kVUb+h8X6BlmoW4173fQ=="
         }
       }
     },
@@ -9292,6 +9287,11 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
+    },
+    "then-read-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/then-read-stream/-/then-read-stream-2.0.0.tgz",
+      "integrity": "sha512-mdQRdZ+71UVL9H6y2bRt/SlpIgzi223LEx8gxbRCfVURnXrokMYo1w+jNcATTZLR25kVUb+h8X6BlmoW4173fQ=="
     },
     "thirty-two": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "location-history": "^1.0.0",
     "material-ui": "^0.20.2",
     "mkdirp": "^0.5.1",
-    "music-metadata": "^4.2.0",
+    "music-metadata": "^4.3.0",
     "network-address": "^1.1.0",
     "parse-torrent": "^7.0.0",
     "prettier-bytes": "^1.0.1",


### PR DESCRIPTION
Update music-metadata to [v4.3.0](https://github.com/Borewit/music-metadata/releases/tag/v4.3.0), improves decoding of MPEG-4-ADTS/AAC encoded audio tracks.