### PR TITLE
Add rpm package creation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ The following optional arguments are available:
 - `--sign` - Sign the application (Mac, Windows)
 - `--package=[type]` - Package single output type.
    - `deb` - Debian package
+   - `rpm` - RedHat package
    - `zip` - Linux zip file
    - `dmg` - Mac disk image
    - `exe` - Windows installer

--- a/bin/package.js
+++ b/bin/package.js
@@ -488,6 +488,9 @@ function buildLinux (cb) {
       if (argv.package === 'deb' || argv.package === 'all') {
         tasks.push((cb) => packageDeb(filesPath, cb))
       }
+      if (argv.package === 'rpm' || argv.package === 'all') {
+        tasks.push((cb) => packageRpm(filesPath, cb))
+      }
       if (argv.package === 'zip' || argv.package === 'all') {
         tasks.push((cb) => packageZip(filesPath, cb))
       }
@@ -520,6 +523,35 @@ function buildLinux (cb) {
     installer(options).then(
       () => {
         console.log('Linux: Created deb.')
+        cb(null)
+      },
+      (err) => cb(err)
+    )
+  }
+
+  function packageRpm (filesPath, cb) {
+    // Create .rpm file for RedHat-based platforms
+    console.log('Linux: Creating rpm...')
+
+    const installer = require('electron-installer-redhat')
+
+    const options = {
+      src: filesPath + '/',
+      dest: DIST_PATH,
+      arch: 'amd64',
+      bin: 'WebTorrent',
+      icon: {
+        '48x48': path.join(config.STATIC_PATH, 'linux/share/icons/hicolor/48x48/apps/webtorrent-desktop.png'),
+        '256x256': path.join(config.STATIC_PATH, 'linux/share/icons/hicolor/256x256/apps/webtorrent-desktop.png')
+      },
+      categories: ['Network', 'FileTransfer', 'P2P'],
+      mimeType: ['application/x-bittorrent', 'x-scheme-handler/magnet', 'x-scheme-handler/stream-magnet'],
+      desktopTemplate: path.join(config.STATIC_PATH, 'linux/webtorrent-desktop.ejs')
+    }
+
+    installer(options).then(
+      () => {
+        console.log('Linux: Created rpm.')
         cb(null)
       },
       (err) => cb(err)

--- a/bin/package.js
+++ b/bin/package.js
@@ -485,12 +485,7 @@ function buildLinux (cb) {
 
     const tasks = []
     buildPath.forEach(function (filesPath) {
-      let destArch = filesPath.split('-').pop()
-
-      // Linux convention for 'x64' is 'amd64'
-      if (destArch === 'x64') {
-        destArch = 'amd64'
-      }
+      const destArch = filesPath.split('-').pop()
 
       if (argv.package === 'deb' || argv.package === 'all') {
         tasks.push((cb) => packageDeb(filesPath, destArch, cb))
@@ -508,6 +503,11 @@ function buildLinux (cb) {
   })
 
   function packageDeb (filesPath, destArch, cb) {
+    // Linux convention for Debian based 'x64' is 'amd64'
+    if (destArch === 'x64') {
+      destArch = 'amd64'
+    }
+
     // Create .deb file for Debian-based platforms
     console.log(`Linux: Creating ${destArch} deb...`)
 
@@ -537,6 +537,11 @@ function buildLinux (cb) {
   }
 
   function packageRpm (filesPath, destArch, cb) {
+    // Linux convention for RedHat based 'x64' is 'x86_64'
+    if (destArch === 'x64') {
+      destArch = 'x86_64'
+    }
+
     // Create .rpm file for RedHat-based platforms
     console.log(`Linux: Creating ${destArch} rpm...`)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1955,7 +1955,6 @@
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/cross-spawn-promise/-/cross-spawn-promise-0.10.1.tgz",
       "integrity": "sha1-25y0xQxgtyoVvgSbeBIs44LYexA=",
-      "optional": true,
       "requires": {
         "cross-spawn": "^5.1.0"
       },
@@ -1964,7 +1963,6 @@
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
           "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-          "optional": true,
           "requires": {
             "lru-cache": "^4.0.1",
             "shebang-command": "^1.2.0",
@@ -2499,7 +2497,6 @@
       "version": "0.7.3",
       "resolved": "https://registry.npmjs.org/electron-installer-common/-/electron-installer-common-0.7.3.tgz",
       "integrity": "sha512-l4chYFTWr6uWODKYUXeC+Z4tqGa3b8e+Y2WUBf3F7Ruv6yYzZ+Ccic65oXreeotx09B7sUx1KTuwXRsRJHKlMw==",
-      "optional": true,
       "requires": {
         "asar": "^2.0.1",
         "cross-spawn-promise": "^0.10.1",
@@ -2516,7 +2513,6 @@
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "optional": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -2525,7 +2521,6 @@
           "version": "8.1.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
           "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-          "optional": true,
           "requires": {
             "graceful-fs": "^4.2.0",
             "jsonfile": "^4.0.0",
@@ -2563,6 +2558,42 @@
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
           "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
           "optional": true,
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        }
+      }
+    },
+    "electron-installer-redhat": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/electron-installer-redhat/-/electron-installer-redhat-2.0.0.tgz",
+      "integrity": "sha512-kf7+/t8XIp1I6LIV9v6K38rBHzmY6bUr3TunJZKdlIKQ7j6wyjjpgbpxSBcg3S7pgzq1kkgCYZvpr8CsLFVivw==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1",
+        "electron-installer-common": "^0.7.1",
+        "fs-extra": "^8.0.1",
+        "lodash": "^4.17.4",
+        "word-wrap": "^1.2.3",
+        "yargs": "^13.2.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "fs-extra": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+          "dev": true,
           "requires": {
             "graceful-fs": "^4.2.0",
             "jsonfile": "^4.0.0",
@@ -9031,7 +9062,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-2.0.2.tgz",
       "integrity": "sha512-zl71nFWjPKW2KXs+73gEk8RmqvtAeXPxhWDkTUoa3MSMkjq3I+9OeknjF178MQoMYsdqL730hfzvNfEkePxq9Q==",
-      "optional": true,
       "requires": {
         "tmp": "0.1.0"
       }
@@ -10015,8 +10045,7 @@
     "word-wrap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-      "optional": true
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
     },
     "wordwrap": {
       "version": "0.0.2",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "build": "buble src --target chrome:71 --output build",
     "clean": "node ./bin/clean.js",
     "gh-release": "gh-release",
-    "install-system-deps": "brew install fakeroot dpkg rpmbuild",
+    "install-system-deps": "brew install fakeroot dpkg rpm",
     "open-config": "node ./bin/open-config.js",
     "package": "node ./bin/package.js",
     "start": "npm run build && electron .",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "build": "buble src --output build",
     "clean": "node ./bin/clean.js",
     "gh-release": "gh-release",
-    "install-system-deps": "brew install fakeroot dpkg",
+    "install-system-deps": "brew install fakeroot dpkg rpmbuild",
     "open-config": "node ./bin/open-config.js",
     "package": "node ./bin/package.js",
     "start": "npm run build && electron .",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,8 @@
   "main": "index.js",
   "optionalDependencies": {
     "appdmg": "^0.6.0",
-    "electron-installer-debian": "^2.0.0"
+    "electron-installer-debian": "^2.0.0",
+    "electron-installer-redhat": "^2.0.0"
   },
   "private": true,
   "productName": "WebTorrent",


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix
[x] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

Given that we have recently added `electron-installer-debian` it is straightforward to add `electron-installer-redhat` and add rpm file creation support.

**Is there anything you'd like reviewers to focus on?**

It would be nice if someone with Fedora could check if the generated package works as expected 😅

Related:
* #1502 _.rpm package for Fedora, etc_