### PR TITLE
Add buble compiler target chrome version

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "url": "git://github.com/webtorrent/webtorrent-desktop.git"
   },
   "scripts": {
-    "build": "buble src --output build",
+    "build": "buble src --target chrome:71 --output build",
     "clean": "node ./bin/clean.js",
     "gh-release": "gh-release",
     "install-system-deps": "brew install fakeroot dpkg",


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix
[ ] New feature
[x] Other, please explain:

**What changes did you make? (Give an overview)**

Given that we are currently in `electron@6.0.9` and that in that release `chromium` is included at version `76`, we can tell `buble` to target this and get rid of all the unnecessary transformations and created a more optimized build 💪

Note: `buble` highest target version for chrome is `71` so this is the one included in this PR.

**Is there anything you'd like reviewers to focus on?**
