### PR TITLE
Set default externalPlayerPath

### DIFF
--- a/src/renderer/lib/migrations.js
+++ b/src/renderer/lib/migrations.js
@@ -29,6 +29,7 @@ function run (state) {
   if (semver.lt(version, '0.17.0')) migrate_0_17_0(saved)
   if (semver.lt(version, '0.17.2')) migrate_0_17_2(saved)
   if (semver.lt(version, '0.21.0')) migrate_0_21_0(saved)
+  if (semver.lt(version, '0.21.1')) migrate_0_21_1(saved)
 
   // Config is now on the new version
   state.saved.version = config.APP_VERSION
@@ -212,5 +213,11 @@ function migrate_0_21_0 (saved) {
   if (saved.prefs.soundNotifications == null) {
     // The app used to always have sound notifications enabled
     saved.prefs.soundNotifications = true
+  }
+}
+
+function migrate_0_21_1 (saved) {
+  if (saved.prefs.externalPlayerPath == null) {
+    saved.prefs.externalPlayerPath = ''
   }
 }

--- a/src/renderer/lib/state.js
+++ b/src/renderer/lib/state.js
@@ -119,7 +119,7 @@ function setupStateSaved () {
       downloadPath: config.DEFAULT_DOWNLOAD_PATH,
       isFileHandler: false,
       openExternalPlayer: false,
-      externalPlayerPath: null,
+      externalPlayerPath: '',
       startup: false,
       soundNotifications: true,
       autoAddTorrents: false,
@@ -207,6 +207,8 @@ function load (cb) {
         onSavedState(err)
         return
       }
+    } else if (saved.prefs.externalPlayerPath == null) {
+      saved.prefs.externalPlayerPath = ''
     }
     onSavedState(null, saved)
   })

--- a/src/renderer/lib/state.js
+++ b/src/renderer/lib/state.js
@@ -207,8 +207,6 @@ function load (cb) {
         onSavedState(err)
         return
       }
-    } else if (saved.prefs.externalPlayerPath == null) {
-      saved.prefs.externalPlayerPath = ''
     }
     onSavedState(null, saved)
   })


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other, please explain:

**What changes did you make?**

PR #1498 fixed issue #1652 for `downloadPath` and `torrentsFolderPath`, but not for `externalPlayerPath`. I changed the default value to `""`.

**Is there anything you'd like reviewers to focus on?**

I handled existing config files that have `externalPlayerPath = null` by changing this to `""` when loading the config file. It's not a beautiful solution, but otherwise they have to edit it by hand.