### PR TITLE
Handle null paths in path selector

### DIFF
--- a/src/renderer/components/path-selector.js
+++ b/src/renderer/components/path-selector.js
@@ -32,7 +32,7 @@ class PathSelector extends React.Component {
 
   handleClick () {
     const opts = Object.assign({
-      defaultPath: this.props.value && path.dirname(this.props.value),
+      defaultPath: path.dirname(this.props.value || ''),
       properties: ['openFile', 'openDirectory']
     }, this.props.dialog)
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
Avoid passing null values from `props.value`

Related to #1702, fixes #1652.

This change is more consistent with the current code, but in the future, we should consider
validating the types instead, since we use already React PropTypes.