### PR TITLE
Add --no-sandbox option to desktop files

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "install-system-deps": "brew install fakeroot dpkg rpm",
     "open-config": "node ./bin/open-config.js",
     "package": "node ./bin/package.js",
-    "start": "npm run build && electron .",
+    "start": "npm run build && electron --no-sandbox .",
     "test": "standard && depcheck --ignores=standard,babel-eslint --ignore-dirs=build,dist && node ./bin/extra-lint.js",
     "test-integration": "npm run build && node ./test",
     "update-authors": "./bin/update-authors.sh",

--- a/static/linux/webtorrent-desktop.ejs
+++ b/static/linux/webtorrent-desktop.ejs
@@ -5,7 +5,7 @@ Name=<%= productName %>
 <% if (genericName) { %>GenericName=<%= genericName %><% } %>
 <% if (description) { %>Comment=<%= description %><% } %>
 Icon=<%= name %>
-<% if (name) { %>Exec=<%= name %> %U<% } %>
+<% if (name) { %>Exec=<%= name %> --no-sandbox %U<% } %><%/*HACK: --no-sandbox fixes an Electron 6 bug. See: #1703*/%>
 Terminal=false
 Actions=CreateNewTorrent;OpenTorrentFile;OpenTorrentAddress;
 <% if (mimeType && mimeType.length) { %>MimeType=<%= mimeType.join(';') %>;<% } %>
@@ -15,12 +15,12 @@ StartupNotify=true
 
 [Desktop Action CreateNewTorrent]
 Name=Create New Torrent...
-<% if (name) { %>Exec=<%= name %> -n <% } %>
+<% if (name) { %>Exec=<%= name %> --no-sandbox -n <% } %><%/*HACK: --no-sandbox fixes an Electron 6 bug. See: #1703*/%>
 
 [Desktop Action OpenTorrentFile]
 Name=Open Torrent File...
-<% if (name) { %>Exec=<%= name %> -o <% } %>
+<% if (name) { %>Exec=<%= name %> --no-sandbox -o <% } %><%/*HACK: --no-sandbox fixes an Electron 6 bug. See: #1703*/%>
 
 [Desktop Action OpenTorrentAddress]
 Name=Open Torrent Address...
-<% if (name) { %>Exec=<%= name %> -u <% } %>
+<% if (name) { %>Exec=<%= name %> --no-sandbox -u <% } %><%/*HACK: --no-sandbox fixes an Electron 6 bug. See: #1703*/%>


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

Add `--no-sandbox` option to launch scripts (Desktop files) to temporary fix #1703 issue.

**Is there anything you'd like reviewers to focus on?**

Check on different platforms. I've checked successfully in Ubuntu 18.04.3 LTS and Debian 8 Jessie 