### PR TITLE
Implement clear completed torrents

### DIFF
--- a/src/renderer/components/clear-completed-modal.js
+++ b/src/renderer/components/clear-completed-modal.js
@@ -1,0 +1,28 @@
+const React = require('react')
+
+const ModalOKCancel = require('./modal-ok-cancel')
+const { dispatch, dispatcher } = require('../lib/dispatcher')
+
+module.exports = class ClearTorrentModal extends React.Component {
+  render () {
+    const message = 'Are you sure you want to clear all completed torrents from the list?'
+    const buttonText = 'CLEAR'
+
+    return (
+      <div>
+        <p><strong>{message}</strong></p>
+        <ModalOKCancel
+          cancelText='CANCEL'
+          onCancel={dispatcher('exitModal')}
+          okText={buttonText}
+          onOK={handleRemove}
+        />
+      </div>
+    )
+
+    function handleRemove () {
+      dispatch('clearCompletedTorrents')
+      dispatch('exitModal')
+    }
+  }
+}

--- a/src/renderer/components/header.js
+++ b/src/renderer/components/header.js
@@ -32,6 +32,9 @@ class Header extends React.Component {
         <div className='nav right float-right'>
           {this.getAddButton()}
         </div>
+        <div className='nav right float-right'>
+          {this.getClearCompletedButton()}
+        </div>
       </div>
     )
   }
@@ -52,6 +55,20 @@ class Header extends React.Component {
         onClick={dispatcher('openFiles')}
       >
         add
+      </i>
+    )
+  }
+
+  getClearCompletedButton () {
+    const state = this.props.state
+    if (state.location.url() !== 'home') return null
+    return (
+      <i
+        className='icon add'
+        title='Clear completed torrents'
+        onClick={dispatcher('confirmClearCompletedTorrents')}
+      >
+        clear_all
       </i>
     )
   }

--- a/src/renderer/controllers/torrent-list-controller.js
+++ b/src/renderer/controllers/torrent-list-controller.js
@@ -227,6 +227,22 @@ module.exports = class TorrentListController {
     sound.play('DELETE')
   }
 
+  confirmClearCompletedTorrents () {
+    this.state.modal = {
+      id: 'clear-completed-modal'
+    }
+  }
+
+  clearCompletedTorrents () {
+    this.state.saved.torrents
+      .filter(
+        torrentSummary =>
+          torrentSummary.progress &&
+          torrentSummary.progress.progress === 1
+      )
+      .forEach(torrentSummary => this.deleteTorrent(torrentSummary.infoHash, false))
+  }
+
   toggleSelectTorrent (infoHash) {
     if (this.state.selectedInfoHash === infoHash) {
       this.state.selectedInfoHash = null

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -251,6 +251,10 @@ const dispatchHandlers = {
     controllers.torrentList().confirmDeleteTorrent(infoHash, deleteData),
   deleteTorrent: (infoHash, deleteData) =>
     controllers.torrentList().deleteTorrent(infoHash, deleteData),
+  confirmClearCompletedTorrents: () =>
+    controllers.torrentList().confirmClearCompletedTorrents(),
+  clearCompletedTorrents: () =>
+    controllers.torrentList().clearCompletedTorrents(),
   toggleSelectTorrent: (infoHash) =>
     controllers.torrentList().toggleSelectTorrent(infoHash),
   openTorrentContextMenu: (infoHash) =>

--- a/src/renderer/pages/app.js
+++ b/src/renderer/pages/app.js
@@ -23,6 +23,7 @@ const Modals = {
     () => require('../components/open-torrent-address-modal')
   ),
   'remove-torrent-modal': createGetter(() => require('../components/remove-torrent-modal')),
+  'clear-completed-modal': createGetter(() => require('../components/clear-completed-modal')),
   'update-available-modal': createGetter(() => require('../components/update-available-modal')),
   'unsupported-media-modal': createGetter(() => require('../components/unsupported-media-modal'))
 }


### PR DESCRIPTION
**What is the purpose of this pull request?**

[ ] Documentation update
[ ] Bug fix
[X] New feature
[ ] Other, please explain:

**What changes did you make?**

Adds the following new button to the header: 

![image](https://user-images.githubusercontent.com/6934200/65410694-e307f980-dd9f-11e9-8712-5aeac81b6f4f.png)

When clicked, it will pop up the following confirmation dialog: 

![image](https://user-images.githubusercontent.com/6934200/65410650-ca97df00-dd9f-11e9-8da0-8034ceeb3168.png)

Once confirmed, it will remove all torrents from the list where progress is 1 (indicating torrent has finished downloading).

I've found this to be an indispensable quality of life feature for keeping the torrent list tidy, much more convenient than hunting down the X button for every torrent on the list. 

Happy to make any changes necessary to get this feature into core in some shape or form.

**Is there anything you'd like reviewers to focus on?**

- UX feedback
- Testing suggestions
