### PR TITLE
Report when files are being verified

### DIFF
--- a/src/renderer/pages/torrent-list-page.js
+++ b/src/renderer/pages/torrent-list-page.js
@@ -212,7 +212,9 @@ module.exports = class TorrentList extends React.Component {
         else if (torrentSummary.progress.progress === 1) status = 'Not seeding'
         else status = 'Paused'
       } else if (torrentSummary.status === 'downloading') {
-        status = 'Downloading'
+        if (!torrentSummary.progress) status = ''
+        else if (!torrentSummary.progress.ready) status = 'Verifying'
+        else status = 'Downloading'
       } else if (torrentSummary.status === 'seeding') {
         status = 'Seeding'
       } else { // torrentSummary.status is 'new' or something unexpected


### PR DESCRIPTION
When starting a torrent that is partially-downloaded, WebTorrent will now report "Verifying" as it verifies the existing data on disk.

If "Verifying" isn't the correct word, let me know. I just used it because it's what the underlying webtorrent library calls it.

Fixes #1586