### PR TITLE
Update music-metadata to v4.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1955,6 +1955,7 @@
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/cross-spawn-promise/-/cross-spawn-promise-0.10.1.tgz",
       "integrity": "sha1-25y0xQxgtyoVvgSbeBIs44LYexA=",
+      "optional": true,
       "requires": {
         "cross-spawn": "^5.1.0"
       },
@@ -1963,6 +1964,7 @@
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
           "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+          "optional": true,
           "requires": {
             "lru-cache": "^4.0.1",
             "shebang-command": "^1.2.0",
@@ -2497,6 +2499,7 @@
       "version": "0.7.3",
       "resolved": "https://registry.npmjs.org/electron-installer-common/-/electron-installer-common-0.7.3.tgz",
       "integrity": "sha512-l4chYFTWr6uWODKYUXeC+Z4tqGa3b8e+Y2WUBf3F7Ruv6yYzZ+Ccic65oXreeotx09B7sUx1KTuwXRsRJHKlMw==",
+      "optional": true,
       "requires": {
         "asar": "^2.0.1",
         "cross-spawn-promise": "^0.10.1",
@@ -2513,6 +2516,7 @@
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "optional": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -2521,6 +2525,7 @@
           "version": "8.1.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
           "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+          "optional": true,
           "requires": {
             "graceful-fs": "^4.2.0",
             "jsonfile": "^4.0.0",
@@ -2570,7 +2575,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/electron-installer-redhat/-/electron-installer-redhat-2.0.0.tgz",
       "integrity": "sha512-kf7+/t8XIp1I6LIV9v6K38rBHzmY6bUr3TunJZKdlIKQ7j6wyjjpgbpxSBcg3S7pgzq1kkgCYZvpr8CsLFVivw==",
-      "dev": true,
+      "optional": true,
       "requires": {
         "debug": "^4.1.1",
         "electron-installer-common": "^0.7.1",
@@ -2584,7 +2589,7 @@
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
+          "optional": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -2593,7 +2598,7 @@
           "version": "8.1.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
           "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-          "dev": true,
+          "optional": true,
           "requires": {
             "graceful-fs": "^4.2.0",
             "jsonfile": "^4.0.0",
@@ -5640,9 +5645,9 @@
       }
     },
     "music-metadata": {
-      "version": "4.5.3",
-      "resolved": "https://registry.npmjs.org/music-metadata/-/music-metadata-4.5.3.tgz",
-      "integrity": "sha512-VXIr9hGJyxcdyqOlUmn+c4wM8f1FAyLyxV12L1pYC5Zb/MKElrh2JmGTLBSy23DN27uBA4QbqhfOOtkvd9H6Mw==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/music-metadata/-/music-metadata-4.8.0.tgz",
+      "integrity": "sha512-eQp9mDTwg8WEqVRIEj1lUuqZ4qiQvXa71ipotkPFKch4ekTAtGTzU/TXAi7DhCeHsZB8WLfGUBTFN1NGBE1iOQ==",
       "requires": {
         "content-type": "^1.0.4",
         "debug": "^4.1.0",
@@ -9062,6 +9067,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-2.0.2.tgz",
       "integrity": "sha512-zl71nFWjPKW2KXs+73gEk8RmqvtAeXPxhWDkTUoa3MSMkjq3I+9OeknjF178MQoMYsdqL730hfzvNfEkePxq9Q==",
+      "optional": true,
       "requires": {
         "tmp": "0.1.0"
       }
@@ -10045,7 +10051,8 @@
     "word-wrap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "optional": true
     },
     "wordwrap": {
       "version": "0.0.2",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "location-history": "^1.1.1",
     "material-ui": "^0.20.2",
     "mkdirp": "^0.5.1",
-    "music-metadata": "^4.5.3",
+    "music-metadata": "^4.8.0",
     "network-address": "^1.1.2",
     "parse-torrent": "^7.0.1",
     "prettier-bytes": "^1.0.4",


### PR DESCRIPTION
Update music-metadata to [v4.8.0](https://github.com/Borewit/music-metadata/releases/tag/v4.8.0).

No major changes, small [bug fix](https://github.com/Borewit/music-metadata/issues/266) which can occur parsing a FLAC file, which embeds cover art in non standard way.