### PR TITLE
Added new preference to for minimizing to tray

### DIFF
--- a/src/main/windows/main.js
+++ b/src/main/windows/main.js
@@ -99,7 +99,7 @@ function init (state, options) {
   win.on('close', e => {
     if (process.platform !== 'darwin') {
       const tray = require('../tray')
-      if (!tray.hasTray()) {
+      if (!tray.hasTray() || !state.saved.prefs.minimizeToTray) {
         app.quit()
         return
       }

--- a/src/renderer/lib/state.js
+++ b/src/renderer/lib/state.js
@@ -129,7 +129,8 @@ function setupStateSaved () {
       soundNotifications: true,
       autoAddTorrents: false,
       torrentsFolderPath: '',
-      highestPlaybackPriority: true
+      highestPlaybackPriority: true,
+      minimizeToTray: true
     },
     torrents: config.DEFAULT_TORRENTS.map(createTorrentObject),
     torrentsToResume: [],

--- a/src/renderer/pages/preferences-page.js
+++ b/src/renderer/pages/preferences-page.js
@@ -221,6 +221,23 @@ class PreferencesPage extends React.Component {
     )
   }
 
+  minimizeToTrayCheckbox () {
+    return (
+      <Preference>
+        <Checkbox
+          className='control'
+          checked={this.props.state.saved.prefs.minimizeToTray}
+          label='Minimize to tray'
+          onCheck={this.handleMinimizeToTrayChange}
+          />
+      </Preference>
+    )
+  }
+
+  handleMinimizeToTrayChange (e, isChecked) {
+    dispatch('updatePreferences', 'minimizeToTray', isChecked)
+  }
+
   handleSoundNotificationsChange (e, isChecked) {
     dispatch('updatePreferences', 'soundNotifications', isChecked)
   }
@@ -253,6 +270,7 @@ class PreferencesPage extends React.Component {
         <PreferencesSection title='General'>
           {this.setStartupCheckbox()}
           {this.soundNotificationsCheckbox()}
+          {this.minimizeToTrayCheckbox()}
         </PreferencesSection>
       </div>
     )


### PR DESCRIPTION
**What is the purpose of this pull request?**

[ ] Documentation update
[ ] Bug fix
[X] New feature
[ ] Other, please explain:

This PR solves issues #1249

**What changes did you make?**
I added a new preference **Minimize to tray**.
This setting saved to the pref config as a boolean value with the default being true.
Added small piece of logic in the `win.on('close')` event to check for this setting.

**Is there anything you'd like reviewers to focus on?**
- Is my logic correct for the `win.on('close')`
- Do I need to add a migration for this?
