### PR TITLE
Fixed Material UI Getting Started link

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ React.js (Framework to work with Frontend UI):
 https://reactjs.org/docs/getting-started.html
 
 Material UI (React components that implement Google's Material Design.):
-https://material-ui.com/getting-started
+https://material-ui.com/getting-started/installation
 
 ### Privacy
 


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [x] Documentation update

**What changes did you make?**
Looks like Material UI changed the URL to their "Getting Started" Page. The old URL shows a 404 Not Found error message. However, the README.md file in webtorrent-desktop was still referring to the broken link. This PR fixes the broken link to the "Getting Started" page of Material UI in the README.md to go to the installation page of Material UI.

**Which issue (if any) does this pull request address?**
#1734 

**Is there anything you'd like reviewers to focus on?**
- I am not sure if I should have suffixed the URL with a forward-slash or not. The new URL seems to work - with or without a slash. I have chosen not to suffix with forward-slash.
  - Without forward-slash suffix: <https://material-ui.com/getting-started/installation>
  - With forward-slash suffix: <https://material-ui.com/getting-started/installation/>
- I am not sure to point the developers to the [Installation page](https://material-ui.com/getting-started/installation) or the [Usage page](https://material-ui.com/getting-started/usage). Both seem like good candidates to point a developer to. I have chosen the [Installation page](https://material-ui.com/getting-started/installation) page because it seemed like that's the starting point in the logical flow of their website.