### PR TITLE
Update music-metadata to 4.9.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3737,9 +3737,9 @@
       }
     },
     "file-type": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-12.3.1.tgz",
-      "integrity": "sha512-FXxY5h6vSYMjrRal4YqbtfuoKD/oE0AMjJ7E5Hm+BdaQECcFVD03B41RAWYJ7wyuLr/wRnCtFo7y37l+nh+TAA=="
+      "version": "12.4.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-12.4.0.tgz",
+      "integrity": "sha512-WTvyKq8yjtNmUtVAD8LGcTkvtCdJglM6ks2HTqEClm6+65XTqM6MoZYA1Vtra50DLRWLiM38fEs1y56f5VhnUA=="
     },
     "filestream": {
       "version": "5.0.0",
@@ -5866,16 +5866,16 @@
       }
     },
     "music-metadata": {
-      "version": "4.8.2",
-      "resolved": "https://registry.npmjs.org/music-metadata/-/music-metadata-4.8.2.tgz",
-      "integrity": "sha512-8Z/tqNRY8O35+bkYd5yAzKBEqkL/mZdWcwyYJ2o7rMpHoAYNASOI/cUGKAKip7biweYuzNEUh709zpvS3yQsHw==",
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/music-metadata/-/music-metadata-4.9.2.tgz",
+      "integrity": "sha512-jxeqyVNHVpC2ogJVpHeo64jsMSakwUQ4vbBY9dyvght54TKcmQ1Whh46Le37Uc0om3v5wrJ6uh3qYTx7bWMEVg==",
       "requires": {
         "content-type": "^1.0.4",
         "debug": "^4.1.0",
-        "file-type": "^12.1.0",
+        "file-type": "^12.4.0",
         "media-typer": "^1.1.0",
-        "strtok3": "^3.0.4",
-        "token-types": "^1.0.4"
+        "strtok3": "^3.1.0",
+        "token-types": "^1.1.0"
       },
       "dependencies": {
         "debug": {
@@ -9005,13 +9005,13 @@
       "dev": true
     },
     "strtok3": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-3.0.4.tgz",
-      "integrity": "sha512-mVyL8lmjC29raM131DYFKqwoOy78GWYWB5wY5I0ycqPzPshKchsehm7DPVP8UQH6vqXCS9Wd8dVj+/bEVQjJkQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-3.1.0.tgz",
+      "integrity": "sha512-p1GtkNh8xMm40GVmhcVyH8eOxAYhsC7aQd5Fe5btLEVR0QhLc9tmOsvmYKAmyQbIuE3SlGfhkdzugonHjNqpQA==",
       "requires": {
         "debug": "^4.1.1",
-        "then-read-stream": "^2.0.7",
-        "token-types": "^1.0.4"
+        "then-read-stream": "^2.0.8",
+        "token-types": "^1.1.0"
       },
       "dependencies": {
         "debug": {
@@ -9212,9 +9212,9 @@
       "dev": true
     },
     "then-read-stream": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/then-read-stream/-/then-read-stream-2.0.7.tgz",
-      "integrity": "sha512-UhIYV6kjtqlnmb/3Pzk4U5c27Bx45XQgLhgKRkMRO/uFR2V9YN25zvXFh5Qzu5lGJul4fSHQI74Sw96wFB6ZpA=="
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/then-read-stream/-/then-read-stream-2.0.8.tgz",
+      "integrity": "sha512-OIQn3/zF2J/gp6mAQTbBb1AR+3yoSRqjaij0gGnEUcTl93T840mWIZ9sJWwubjwP7VUDwJpT+Tdl7T9RrQmMlw=="
     },
     "thirty-two": {
       "version": "1.0.2",
@@ -9393,9 +9393,9 @@
       }
     },
     "token-types": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/token-types/-/token-types-1.0.4.tgz",
-      "integrity": "sha512-Qhg+62OTm+ip8f6Ko1ylxas2G0ailgvIsHk0gvTmNWDNdQfcN30niH5MoRcVbKdHrHpiWhY159FBUiZkaNzh1w=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-1.1.0.tgz",
+      "integrity": "sha512-CgM5GmtJaZ+uTOiZHzs9pwUa/udjEVl/cxQ2KGpl88Hh7k71sdBz9j95dYjx83O68B6CGvefm29l4rBZq1PeuQ=="
     },
     "torrent-discovery": {
       "version": "9.2.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "location-history": "^1.1.1",
     "material-ui": "^0.20.2",
     "mkdirp": "^0.5.1",
-    "music-metadata": "^4.8.2",
+    "music-metadata": "4.9.2",
     "network-address": "^1.1.2",
     "parse-torrent": "^7.0.1",
     "prettier-bytes": "^1.0.4",


### PR DESCRIPTION
Update to [music-metadata 4.9.2](https://github.com/Borewit/music-metadata/tree/v4.9.2)

Fix issues that may cause an error parsing an MP4 file.

This not the latest, this should be very stable, I don't foresee any risk updating.