### PR TITLE
Fix deprecated dialog callback functions

### DIFF
--- a/src/main/dialog.js
+++ b/src/main/dialog.js
@@ -61,11 +61,10 @@ function openFiles () {
       properties: ['openFile']
     }
   setTitle(opts.title)
-  electron.dialog.showOpenDialog(windows.main.win, opts, function (selectedPaths) {
-    resetTitle()
-    if (!Array.isArray(selectedPaths)) return
-    windows.main.dispatch('onOpen', selectedPaths)
-  })
+  const selectedPaths = electron.dialog.showOpenDialogSync(windows.main.win, opts)
+  resetTitle()
+  if (!Array.isArray(selectedPaths)) return
+  windows.main.dispatch('onOpen', selectedPaths)
 }
 
 /*
@@ -80,12 +79,11 @@ function openTorrentFile () {
     properties: ['openFile', 'multiSelections']
   }
   setTitle(opts.title)
-  electron.dialog.showOpenDialog(windows.main.win, opts, function (selectedPaths) {
-    resetTitle()
-    if (!Array.isArray(selectedPaths)) return
-    selectedPaths.forEach(function (selectedPath) {
-      windows.main.dispatch('addTorrent', selectedPath)
-    })
+  const selectedPaths = electron.dialog.showOpenDialogSync(windows.main.win, opts)
+  resetTitle()
+  if (!Array.isArray(selectedPaths)) return
+  selectedPaths.forEach(function (selectedPath) {
+    windows.main.dispatch('addTorrent', selectedPath)
   })
 }
 
@@ -116,9 +114,8 @@ function resetTitle () {
  */
 function showOpenSeed (opts) {
   setTitle(opts.title)
-  electron.dialog.showOpenDialog(windows.main.win, opts, function (selectedPaths) {
-    resetTitle()
-    if (!Array.isArray(selectedPaths)) return
-    windows.main.dispatch('showCreateTorrent', selectedPaths)
-  })
+  const selectedPaths = electron.dialog.showOpenDialogSync(windows.main.win, opts)
+  resetTitle()
+  if (!Array.isArray(selectedPaths)) return
+  windows.main.dispatch('showCreateTorrent', selectedPaths)
 }

--- a/src/renderer/components/path-selector.js
+++ b/src/renderer/components/path-selector.js
@@ -36,14 +36,9 @@ class PathSelector extends React.Component {
       properties: ['openFile', 'openDirectory']
     }, this.props.dialog)
 
-    remote.dialog.showOpenDialog(
-      remote.getCurrentWindow(),
-      opts,
-      (filenames) => {
-        if (!Array.isArray(filenames)) return
-        this.props.onChange && this.props.onChange(filenames[0])
-      }
-    )
+    const filenames = remote.dialog.showOpenDialogSync(remote.getCurrentWindow(), opts)
+    if (!Array.isArray(filenames)) return
+    this.props.onChange && this.props.onChange(filenames[0])
   }
 
   render () {

--- a/src/renderer/controllers/subtitles-controller.js
+++ b/src/renderer/controllers/subtitles-controller.js
@@ -13,14 +13,13 @@ module.exports = class SubtitlesController {
   }
 
   openSubtitles () {
-    remote.dialog.showOpenDialog({
+    const filenames = remote.dialog.showOpenDialogSync({
       title: 'Select a subtitles file.',
       filters: [{ name: 'Subtitles', extensions: ['vtt', 'srt'] }],
       properties: ['openFile']
-    }, (filenames) => {
-      if (!Array.isArray(filenames)) return
-      this.addSubtitles(filenames, true)
     })
+    if (!Array.isArray(filenames)) return
+    this.addSubtitles(filenames, true)
   }
 
   selectSubtitle (ix) {

--- a/test/mocks.js
+++ b/test/mocks.js
@@ -4,9 +4,6 @@ const config = require('./config')
 console.log('Mocking electron.dialog.showOpenDialogSync...')
 electron.dialog.showOpenDialogSync = showOpenDialogSync
 
-console.log('Mocking electron.remote.dialog.showOpenDialogSync...')
-electron.remote.dialog.showOpenDialogSync = showOpenDialogSync
-
 function showOpenDialogSync (win, opts) {
   return /select.*torrent file/i.test(opts.title)
     ? config.TORRENT_FILES
@@ -15,9 +12,6 @@ function showOpenDialogSync (win, opts) {
 
 console.log('Mocking electron.dialog.showSaveDialogSync...')
 electron.dialog.showSaveDialogSync = showSaveDialogSync
-
-console.log('Mocking electron.remote.dialog.showSaveDialogSync...')
-electron.remote.dialog.showSaveDialogSync = showSaveDialogSync
 
 function showSaveDialogSync (win, opts) {
   return config.SAVED_TORRENT_FILE

--- a/test/mocks.js
+++ b/test/mocks.js
@@ -1,15 +1,24 @@
 const electron = require('electron')
 const config = require('./config')
 
-console.log('Mocking electron.dialog.showOpenDialog...')
-electron.dialog.showOpenDialog = function (win, opts, cb) {
-  const ret = /select.*torrent file/i.test(opts.title)
+console.log('Mocking electron.dialog.showOpenDialogSync...')
+electron.dialog.showOpenDialogSync = showOpenDialogSync
+
+console.log('Mocking electron.remote.dialog.showOpenDialogSync...')
+electron.remote.dialog.showOpenDialogSync = showOpenDialogSync
+
+function showOpenDialogSync (win, opts) {
+  return /select.*torrent file/i.test(opts.title)
     ? config.TORRENT_FILES
     : config.SEED_FILES
-  cb(ret)
 }
 
-console.log('Mocking electron.remote.dialog.showSaveDialog...')
-electron.dialog.showSaveDialog = function (win, opts, cb) {
-  cb(config.SAVED_TORRENT_FILE)
+console.log('Mocking electron.dialog.showSaveDialogSync...')
+electron.dialog.showSaveDialogSync = showSaveDialogSync
+
+console.log('Mocking electron.remote.dialog.showSaveDialogSync...')
+electron.remote.dialog.showSaveDialogSync = showSaveDialogSync
+
+function showSaveDialogSync (win, opts) {
+  return config.SAVED_TORRENT_FILE
 }


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
This PR updates dialog functions to use up to date *Sync versions. 

**Which issue (if any) does this pull request address?**
When updating to `electron@7.0.0` dialog with callback functions have been deprecated, so I've updated with the up to date ones.

**Is there anything you'd like reviewers to focus on?**
