### PR TITLE
Remove deep-equal dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "chromecasts": "^1.9.1",
     "create-torrent": "^4.4.1",
     "debounce": "^1.2.0",
-    "deep-equal": "^1.1.0",
     "dlnacasts": "^0.1.0",
     "drag-drop": "^6.0.0",
     "es6-error": "^4.1.1",

--- a/src/renderer/webtorrent.js
+++ b/src/renderer/webtorrent.js
@@ -3,7 +3,7 @@
 console.time('init')
 
 const crypto = require('crypto')
-const deepEqual = require('deep-equal')
+const util = require('util')
 const defaultAnnounceList = require('create-torrent').announceList
 const electron = require('electron')
 const fs = require('fs')
@@ -249,7 +249,7 @@ function generateTorrentPoster (torrentKey) {
 function updateTorrentProgress () {
   const progress = getTorrentProgress()
   // TODO: diff torrent-by-torrent, not once for the whole update
-  if (prevProgress && deepEqual(progress, prevProgress, { strict: true })) {
+  if (prevProgress && util.isDeepStrictEqual(progress, prevProgress)) {
     return /* don't send heavy object if it hasn't changed */
   }
   ipc.send('wt-progress', progress)


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix
[ ] New feature
[x] Other, please explain:

Remove external `deep-equal` dependency in favor of nodejs internal `util.isDeepStrictEqual` one.

**What changes did you make? (Give an overview)**
Just replace `deep-equal` dependency in favor of nodejs internal `util.isDeepStrictEqual`

**Which issue (if any) does this pull request address?**
Removes an external dependency and uses a faster (~3x) nodejs internal one.

**Is there anything you'd like reviewers to focus on?**
