### PR TITLE
Update music metadata 6.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2738,6 +2738,7 @@
         "rcedit": "^2.0.0",
         "resolve": "^1.1.6",
         "sanitize-filename": "^1.6.0",
+        "semver": "^6.0.0",
         "yargs-parser": "^13.0.0"
       },
       "dependencies": {
@@ -2760,6 +2761,12 @@
             "jsonfile": "^4.0.0",
             "universalify": "^0.1.0"
           }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
         }
       }
     },
@@ -2933,6 +2940,7 @@
         "optionator": "^0.8.2",
         "progress": "^2.0.0",
         "regexpp": "^2.0.1",
+        "semver": "^6.1.2",
         "strip-ansi": "^5.2.0",
         "strip-json-comments": "^3.0.1",
         "table": "^5.2.3",
@@ -2983,6 +2991,12 @@
           "requires": {
             "ms": "^2.1.1"
           }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
         },
         "strip-ansi": {
           "version": "5.2.0",
@@ -3198,13 +3212,20 @@
         "eslint-utils": "^1.4.2",
         "ignore": "^5.1.1",
         "minimatch": "^3.0.4",
-        "resolve": "^1.10.1"
+        "resolve": "^1.10.1",
+        "semver": "^6.1.0"
       },
       "dependencies": {
         "ignore": {
           "version": "5.1.4",
           "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
           "integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==",
+          "dev": true
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
         }
       }
@@ -5078,7 +5099,17 @@
     "make-dir": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.0.tgz",
-      "integrity": "sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw=="
+      "integrity": "sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==",
+      "requires": {
+        "semver": "^6.0.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+        }
+      }
     },
     "map-obj": {
       "version": "1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -305,6 +305,11 @@
         "defer-to-connect": "^1.0.1"
       }
     },
+    "@tokenizer/token": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.1.0.tgz",
+      "integrity": "sha512-fXk7a5R+aE8bfDRbfT+xRG2evSatjbljGGSUflfQmqw555My8II/EWly2GmcHaqXF5HCMitBEfSNhCRZCrLGGg=="
+    },
     "@types/long": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.0.tgz",
@@ -3451,9 +3456,9 @@
       }
     },
     "file-type": {
-      "version": "12.4.0",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-12.4.0.tgz",
-      "integrity": "sha512-WTvyKq8yjtNmUtVAD8LGcTkvtCdJglM6ks2HTqEClm6+65XTqM6MoZYA1Vtra50DLRWLiM38fEs1y56f5VhnUA=="
+      "version": "12.4.2",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-12.4.2.tgz",
+      "integrity": "sha512-UssQP5ZgIOKelfsaB5CuGAL+Y+q7EmONuiwF3N5HAH0t27rvrttgi6Ra9k/+DVaY9UF6+ybxu5pOXLUdA8N7Vg=="
     },
     "filestream": {
       "version": "5.0.0",
@@ -4220,8 +4225,7 @@
     "ieee754": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
-      "dev": true
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
     },
     "ignore": {
       "version": "4.0.6",
@@ -5298,16 +5302,16 @@
       }
     },
     "music-metadata": {
-      "version": "4.9.2",
-      "resolved": "https://registry.npmjs.org/music-metadata/-/music-metadata-4.9.2.tgz",
-      "integrity": "sha512-jxeqyVNHVpC2ogJVpHeo64jsMSakwUQ4vbBY9dyvght54TKcmQ1Whh46Le37Uc0om3v5wrJ6uh3qYTx7bWMEVg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/music-metadata/-/music-metadata-6.1.0.tgz",
+      "integrity": "sha512-dgt65LRyNbSlJ6fpa7HoQpdJHCWitLF0m96gifDINnRRi6KDvChHp6fYvujLOkSY2aMY/HLQqEWtX6M7hszSmA==",
       "requires": {
         "content-type": "^1.0.4",
         "debug": "^4.1.0",
-        "file-type": "^12.4.0",
+        "file-type": "^12.4.2",
         "media-typer": "^1.1.0",
-        "strtok3": "^3.1.0",
-        "token-types": "^1.1.0"
+        "strtok3": "^5.0.0",
+        "token-types": "^2.0.0"
       },
       "dependencies": {
         "debug": {
@@ -7466,13 +7470,13 @@
       "dev": true
     },
     "strtok3": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-3.1.0.tgz",
-      "integrity": "sha512-p1GtkNh8xMm40GVmhcVyH8eOxAYhsC7aQd5Fe5btLEVR0QhLc9tmOsvmYKAmyQbIuE3SlGfhkdzugonHjNqpQA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-5.0.0.tgz",
+      "integrity": "sha512-HpdgEUSkMqlTjO7uWEBvWHEKBYqXCbVeihlE+sa0keGsfVXspVxye1dPa4OYvnzOJsErzn6ohQU1U/ozcVAPKQ==",
       "requires": {
+        "@tokenizer/token": "^0.1.0",
         "debug": "^4.1.1",
-        "then-read-stream": "^2.0.8",
-        "token-types": "^1.1.0"
+        "then-read-stream": "^3.0.0"
       },
       "dependencies": {
         "debug": {
@@ -7673,9 +7677,9 @@
       "dev": true
     },
     "then-read-stream": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/then-read-stream/-/then-read-stream-2.0.8.tgz",
-      "integrity": "sha512-OIQn3/zF2J/gp6mAQTbBb1AR+3yoSRqjaij0gGnEUcTl93T840mWIZ9sJWwubjwP7VUDwJpT+Tdl7T9RrQmMlw=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/then-read-stream/-/then-read-stream-3.0.0.tgz",
+      "integrity": "sha512-4rrXPPD+MRft1kzKj8qe9Lo0qoz+uEkwn6QxWSM4iXux3p7MP72Oq/QJ849/yhmHweOJJI8jJsMjKvAjI33+2A=="
     },
     "thirty-two": {
       "version": "1.0.2",
@@ -7822,9 +7826,13 @@
       }
     },
     "token-types": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/token-types/-/token-types-1.1.0.tgz",
-      "integrity": "sha512-CgM5GmtJaZ+uTOiZHzs9pwUa/udjEVl/cxQ2KGpl88Hh7k71sdBz9j95dYjx83O68B6CGvefm29l4rBZq1PeuQ=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-2.0.0.tgz",
+      "integrity": "sha512-WWvu8sGK8/ZmGusekZJJ5NM6rRVTTDO7/bahz4NGiSDb/XsmdYBn6a1N/bymUHuWYTWeuLUg98wUzvE4jPdCZw==",
+      "requires": {
+        "@tokenizer/token": "^0.1.0",
+        "ieee754": "^1.1.13"
+      }
     },
     "torrent-discovery": {
       "version": "9.2.1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "location-history": "^1.1.1",
     "material-ui": "^0.20.2",
     "mkdirp": "^0.5.1",
-    "music-metadata": "4.9.2",
+    "music-metadata": "6.1.0",
     "network-address": "^1.1.2",
     "parse-torrent": "^7.0.1",
     "prettier-bytes": "^1.0.4",

--- a/src/renderer/lib/media-extensions.js
+++ b/src/renderer/lib/media-extensions.js
@@ -1,8 +1,8 @@
 const mediaExtensions = {
   audio: [
     '.aac', '.aif', '.aiff', '.asf', '.dff', '.dsf', '.flac', '.m2a',
-    '.m4a', '.m4b', '.mp2', '.mp3', '.mpc', '.oga', '.ogg', '.opus',
-    '.spx', '.wma', '.wav', '.wv', '.wvp'],
+    '.m2a', '.m4a', '.mpc', '.m4b', '.mka', '.mp2', '.mp3', '.mpc', '.oga',
+    '.ogg', '.opus', '.spx', '.wma', '.wav', '.wv', '.wvp'],
   video: [
     '.avi', '.mp4', '.m4v', '.webm', '.mov', '.mkv', '.mpg', '.mpeg',
     '.ogv', '.webm', '.wmv'],

--- a/src/renderer/webtorrent.js
+++ b/src/renderer/webtorrent.js
@@ -351,15 +351,18 @@ function getAudioMetadata (infoHash, index) {
       ipc.send('wt-audio-metadata', infoHash, index, event.metadata)
     }
   }
-  const onMetaData = file.done
+  const onMetadata = file.done
     // If completed; use direct file access
     ? mm.parseFile(path.join(torrent.path, file.path), options)
     // otherwise stream
     : mm.parseStream(file.createReadStream(), file.name, options)
 
-  onMetaData
+  onMetadata
     .then(
-      () => console.log(`metadata for file='${file.name}' completed.`),
+      metadata => {
+        ipc.send('wt-audio-metadata', infoHash, index, metadata)
+        console.log(`metadata for file='${file.name}' completed.`)
+      },
       err => {
         console.log(
           `error getting audio metadata for ${infoHash}:${index}`,


### PR DESCRIPTION
Update dependency to [music-metadata v6.1.0](https://github.com/Borewit/music-metadata/releases/tag/v6.1.0)

Changes:
1. Update call to `parseStream` with [IFileInfo](https://github.com/Borewit/strtok3#IFileInfo), to adopt to [music-metadata v6 API](https://github.com/Borewit/music-metadata/releases/tag/v6.0.0)
2. If the parsing of the file (or torrent stream) has completed, send a final update event with metadata.
3. Renamed promise `onMetaData` to `onMetadata`
4. Add additional audio extensions (which mostly helps to determine if torrent is audio torrent):

| extension | Description                                                     |
|-----------|-----------------------------------------------------------------|
| .m2a      | [MPEG-1 Layer 2 Audio File](https://fileinfo.com/extension/m2a) |
| .mka      | [Matroska audio](https://www.matroska.org/)                     |
| .mpc      | [Musepack](https://www.musepack.net/)                           |
| .wv       | [WavePack](http://www.wavpack.com/)                             ||