### PR TITLE
Automatically keep the copyright year up-to-date

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -23,7 +23,7 @@ module.exports = {
   CRASH_REPORT_URL: 'https://webtorrent.io/desktop/crash-report',
   TELEMETRY_URL: 'https://webtorrent.io/desktop/telemetry',
 
-  APP_COPYRIGHT: `Copyright © 2014-${(new Date()).getFullYear()} ${APP_TEAM}`,
+  APP_COPYRIGHT: `Copyright © 2014-${new Date().getFullYear()} ${APP_TEAM}`,
   APP_FILE_ICON: path.join(__dirname, '..', 'static', 'WebTorrentFile'),
   APP_ICON: path.join(__dirname, '..', 'static', 'WebTorrent'),
   APP_NAME: APP_NAME,

--- a/src/config.js
+++ b/src/config.js
@@ -23,7 +23,7 @@ module.exports = {
   CRASH_REPORT_URL: 'https://webtorrent.io/desktop/crash-report',
   TELEMETRY_URL: 'https://webtorrent.io/desktop/telemetry',
 
-  APP_COPYRIGHT: 'Copyright © 2014-2019 ' + APP_TEAM,
+  APP_COPYRIGHT: `Copyright © 2014-${(new Date()).getFullYear()} ${APP_TEAM}`,
   APP_FILE_ICON: path.join(__dirname, '..', 'static', 'WebTorrentFile'),
   APP_ICON: path.join(__dirname, '..', 'static', 'WebTorrent'),
   APP_NAME: APP_NAME,


### PR DESCRIPTION
Last year I manually updated the copyright: https://github.com/webtorrent/webtorrent-desktop/pull/1546. The year before that it was caught by @SimplyAhmazing: https://github.com/webtorrent/webtorrent-desktop/pull/1304. 

But now it's out-of-date again.

This PR sets it to automatically use the current year.

Happy new decade everyone 🥂