### PR TITLE
Greenkeeper/music metadata 6.3.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -306,9 +306,14 @@
       }
     },
     "@tokenizer/token": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.1.0.tgz",
-      "integrity": "sha512-fXk7a5R+aE8bfDRbfT+xRG2evSatjbljGGSUflfQmqw555My8II/EWly2GmcHaqXF5HCMitBEfSNhCRZCrLGGg=="
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.1.1.tgz",
+      "integrity": "sha512-XO6INPbZCxdprl+9qa/AAbFFOMzzwqYxpjPgLICrMD6C2FCw6qfJOPcBk6JqqPLSaZ/Qx87qn4rpPmPMwaAK6w=="
+    },
+    "@types/debug": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.5.tgz",
+      "integrity": "sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ=="
     },
     "@types/long": {
       "version": "4.0.0",
@@ -3477,9 +3482,15 @@
       }
     },
     "file-type": {
-      "version": "12.4.2",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-12.4.2.tgz",
-      "integrity": "sha512-UssQP5ZgIOKelfsaB5CuGAL+Y+q7EmONuiwF3N5HAH0t27rvrttgi6Ra9k/+DVaY9UF6+ybxu5pOXLUdA8N7Vg=="
+      "version": "14.1.4",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-14.1.4.tgz",
+      "integrity": "sha512-1n6FczX8n73Y/cLjTiMboeTGHfm/i2AWk2oQE7m9a/G5YTCZHCEHEGr32thhLm3iQNUYzTKVQUcYcNHtOLwqgQ==",
+      "requires": {
+        "readable-web-to-node-stream": "^2.0.0",
+        "strtok3": "^6.0.0",
+        "token-types": "^2.0.0",
+        "typedarray-to-buffer": "^3.1.5"
+      }
     },
     "filestream": {
       "version": "5.0.0",
@@ -5333,15 +5344,15 @@
       }
     },
     "music-metadata": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/music-metadata/-/music-metadata-6.1.0.tgz",
-      "integrity": "sha512-dgt65LRyNbSlJ6fpa7HoQpdJHCWitLF0m96gifDINnRRi6KDvChHp6fYvujLOkSY2aMY/HLQqEWtX6M7hszSmA==",
+      "version": "6.3.6",
+      "resolved": "https://registry.npmjs.org/music-metadata/-/music-metadata-6.3.6.tgz",
+      "integrity": "sha512-fIvyUXEC7+mD+9bgBy0f39E+G+vLMTj+R5Wa7WeV6EPbtLSKj/EmXjJ0hctEX8Vpq3iElGQacqIrHVRm4qKnXA==",
       "requires": {
         "content-type": "^1.0.4",
         "debug": "^4.1.0",
-        "file-type": "^12.4.2",
+        "file-type": "^14.1.3",
         "media-typer": "^1.1.0",
-        "strtok3": "^5.0.0",
+        "strtok3": "^6.0.0",
         "token-types": "^2.0.0"
       },
       "dependencies": {
@@ -5906,6 +5917,11 @@
         "pify": "^2.0.0",
         "pinkie-promise": "^2.0.0"
       }
+    },
+    "peek-readable": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-3.1.0.tgz",
+      "integrity": "sha512-KGuODSTV6hcgdZvDrIDBUkN0utcAVj1LL7FfGbM0viKTtCHmtZcuEJ+lGqsp0fTFkGqesdtemV2yUSMeyy3ddA=="
     },
     "peek-stream": {
       "version": "1.1.3",
@@ -6536,6 +6552,11 @@
         "string_decoder": "~1.1.1",
         "util-deprecate": "~1.0.1"
       }
+    },
+    "readable-web-to-node-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-2.0.0.tgz",
+      "integrity": "sha512-+oZJurc4hXpaaqsN68GoZGQAQIA3qr09Or4fqEsargABnbe5Aau8hFn6ISVleT3cpY/0n/8drn7huyyEvTbghA=="
     },
     "readable-wrap": {
       "version": "1.0.0",
@@ -7501,13 +7522,14 @@
       "dev": true
     },
     "strtok3": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-5.0.0.tgz",
-      "integrity": "sha512-HpdgEUSkMqlTjO7uWEBvWHEKBYqXCbVeihlE+sa0keGsfVXspVxye1dPa4OYvnzOJsErzn6ohQU1U/ozcVAPKQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.0.0.tgz",
+      "integrity": "sha512-ZXlmE22LZnIBvEU3n/kZGdh770fYFie65u5+2hLK9s74DoFtpkQIdBZVeYEzlolpGa+52G5IkzjUWn+iXynOEQ==",
       "requires": {
-        "@tokenizer/token": "^0.1.0",
+        "@tokenizer/token": "^0.1.1",
+        "@types/debug": "^4.1.5",
         "debug": "^4.1.1",
-        "then-read-stream": "^3.0.0"
+        "peek-readable": "^3.1.0"
       },
       "dependencies": {
         "debug": {
@@ -7706,11 +7728,6 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
-    },
-    "then-read-stream": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/then-read-stream/-/then-read-stream-3.0.0.tgz",
-      "integrity": "sha512-4rrXPPD+MRft1kzKj8qe9Lo0qoz+uEkwn6QxWSM4iXux3p7MP72Oq/QJ849/yhmHweOJJI8jJsMjKvAjI33+2A=="
     },
     "thirty-two": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "location-history": "^1.1.1",
     "material-ui": "^0.20.2",
     "mkdirp": "^0.5.1",
-    "music-metadata": "6.1.0",
+    "music-metadata": "6.3.6",
     "network-address": "^1.1.2",
     "parse-torrent": "^7.0.1",
     "prettier-bytes": "^1.0.4",


### PR DESCRIPTION
Update [v6.3.6](https://github.com/Borewit/music-metadata/releases/tag/v6.3.6).
Minor fixes, low risk.

Can we switch to [Dependabot](https://github.com/dependabot) @feross?
Would be convenient if pending PR's are automatically updated to the latest dependency.  

