### PR TITLE
Add macOS Notarization

### DIFF
--- a/bin/darwin-entitlements.plist
+++ b/bin/darwin-entitlements.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.debugger</key>
+    <true/>
+  </dict>
+</plist>

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "cross-zip": "^3.1.0",
     "depcheck": "^1.0.0",
     "electron": "~10.0.0-beta.11",
+    "electron-notarize": "^1.0.0",
     "electron-osx-sign": "^0.4.17",
     "electron-packager": "^15.0.0",
     "electron-winstaller": "^4.0.1",


### PR DESCRIPTION
Fixes: https://github.com/webtorrent/webtorrent-desktop/issues/1675

<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix
[x] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

This PR adds macOS Notarization. macOS 10.15 Catalina requires apps to be "notarized". Since I just published a new version of WebTorrent since Apple started enforcing this requirement, the app is now blocked on first run. This PR fixes that.

**Which issue (if any) does this pull request address?**

Fixes: https://github.com/webtorrent/webtorrent-desktop/issues/1675
