### PR TITLE
Fix audio metadata not being displayed

### DIFF
--- a/src/renderer/webtorrent.js
+++ b/src/renderer/webtorrent.js
@@ -343,7 +343,10 @@ function getAudioMetadata (infoHash, index) {
     skipCovers: true,
     fileSize: file.length,
     observer: event => {
-      ipc.send('wt-audio-metadata', infoHash, index, event.metadata)
+      ipc.send('wt-audio-metadata', infoHash, index, {
+        common: metadata.common,
+        format: metadata.format
+      })
     }
   }
   const onMetadata = file.done


### PR DESCRIPTION
Fix issue #1833.

Problems is that the observable used to retrieve the metadata, close to real-time, is passing the inter [MetadataCollector object](https://github.com/Borewit/music-metadata/blob/master/lib/common/MetadataCollector.ts) which implements the metadata interface. Problem is in this scenario, to pass the data from main to browser, the data is serialized. The solution is simple, just pass the metadata only, which does not contain functions. 

I used this function btw to detect functions inside the event data:
```js
function clone(x) {
  return JSON.stringify(x, (key, value) => {
    if (typeof value === 'function') {
      throw new Error('metadata shall not contain functions');
    }
    return value;
  });
}
```
Using something like `clone(metadata)` to understand what the issue was.

I was in doubt where to put the change, in [music-metadata](https://github.com/Borewit/music-metadata) or [webtorrent](https://github.com/webtorrent). The draw back of putting it in [music-metadata](https://github.com/Borewit/music-metadata) is that the internal object needs be converted to a _clean_ every event. Most application won't notice that they get a bit more then strictly specified in the interface.