### PR TITLE
Update music metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5751,15 +5751,15 @@
       }
     },
     "music-metadata": {
-      "version": "6.3.6",
-      "resolved": "https://registry.npmjs.org/music-metadata/-/music-metadata-6.3.6.tgz",
-      "integrity": "sha512-fIvyUXEC7+mD+9bgBy0f39E+G+vLMTj+R5Wa7WeV6EPbtLSKj/EmXjJ0hctEX8Vpq3iElGQacqIrHVRm4qKnXA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/music-metadata/-/music-metadata-7.0.0.tgz",
+      "integrity": "sha512-v/A4QVS0nTvV49ShgZo/2g2cbvE8UtUbxIXh4W7zG+k40gy83UK1FkLvF0q9nd++mIXn5a+MS6kcrPO1WJBAdQ==",
       "requires": {
         "content-type": "^1.0.4",
         "debug": "^4.1.0",
-        "file-type": "^14.1.3",
+        "file-type": "^14.6.2",
         "media-typer": "^1.1.0",
-        "strtok3": "^6.0.0",
+        "strtok3": "^6.0.3",
         "token-types": "^2.0.0"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "languagedetect": "^2.0.0",
     "location-history": "^1.1.2",
     "material-ui": "^0.20.2",
-    "music-metadata": "6.3.6",
+    "music-metadata": "^7.0.0",
     "network-address": "^1.1.2",
     "parse-torrent": "^7.1.3",
     "prettier-bytes": "^1.0.4",

--- a/src/renderer/webtorrent.js
+++ b/src/renderer/webtorrent.js
@@ -343,7 +343,10 @@ function getAudioMetadata (infoHash, index) {
     skipCovers: true,
     fileSize: file.length,
     observer: event => {
-      ipc.send('wt-audio-metadata', infoHash, index, event.metadata)
+      ipc.send('wt-audio-metadata', infoHash, index, {
+        common: metadata.common,
+        format: metadata.format
+      })
     }
   }
   const onMetadata = file.done


### PR DESCRIPTION
Update [music-metadata](https://github.com/Borewit/music-metadata) to [version 7.0.0.](https://github.com/Borewit/music-metadata/releases/tag/v7.0.0)

Includes PR #1846 as well, which fixes metadata displayed for this and earlier versions.