### PR TITLE
Fix #1807 (VLC does not start)

### DIFF
--- a/src/main/external-player.js
+++ b/src/main/external-player.js
@@ -17,12 +17,12 @@ let proc = null
 function checkInstall (playerPath, cb) {
   // check for VLC if external player has not been specified by the user
   // otherwise assume the player is installed
-  if (playerPath == null) return vlcCommand(cb)
+  if (playerPath.length === 0) return vlcCommand(cb)
   process.nextTick(() => cb(null))
 }
 
 function spawn (playerPath, url, title) {
-  if (playerPath != null) return spawnExternal(playerPath, [url])
+  if (playerPath.length !== 0) return spawnExternal(playerPath, [url])
 
   // Try to find and use VLC if external player is not specified
   vlcCommand((err, vlcPath) => {

--- a/src/main/external-player.js
+++ b/src/main/external-player.js
@@ -17,12 +17,12 @@ let proc = null
 function checkInstall (playerPath, cb) {
   // check for VLC if external player has not been specified by the user
   // otherwise assume the player is installed
-  if (playerPath.length === 0) return vlcCommand(cb)
+  if (!playerPath) return vlcCommand(cb)
   process.nextTick(() => cb(null))
 }
 
 function spawn (playerPath, url, title) {
-  if (playerPath.length !== 0) return spawnExternal(playerPath, [url])
+  if (playerPath) return spawnExternal(playerPath, [url])
 
   // Try to find and use VLC if external player is not specified
   vlcCommand((err, vlcPath) => {


### PR DESCRIPTION
https://github.com/webtorrent/webtorrent-desktop/blob/eb5a291c8b9cbfae96f306e153387e720a7baa72/src/renderer/lib/migrations.js#L219 cause external player to be a empty string instead of a null one

<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
VLC does not start

**Which issue (if any) does this pull request address?**
Fix #1807

**Is there anything you'd like reviewers to focus on?**
