### PR TITLE
Update music-metadata to version 7.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3696,9 +3696,9 @@
       }
     },
     "file-type": {
-      "version": "14.6.2",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-14.6.2.tgz",
-      "integrity": "sha512-kSZTAJxPXBdBgJyoC7TexkBWoMI/D1Gas6aTtAn9VIRFwCehwiluGV5O8O2GwqO5zIqeEvXxEKl/xfcaAKB0Yg==",
+      "version": "14.7.1",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-14.7.1.tgz",
+      "integrity": "sha512-sXAMgFk67fQLcetXustxfKX+PZgHIUFn96Xld9uH8aXPdX3xOp0/jg9OdouVTvQrf7mrn+wAa4jN/y9fUOOiRA==",
       "requires": {
         "readable-web-to-node-stream": "^2.0.0",
         "strtok3": "^6.0.3",
@@ -5751,15 +5751,15 @@
       }
     },
     "music-metadata": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/music-metadata/-/music-metadata-7.0.0.tgz",
-      "integrity": "sha512-v/A4QVS0nTvV49ShgZo/2g2cbvE8UtUbxIXh4W7zG+k40gy83UK1FkLvF0q9nd++mIXn5a+MS6kcrPO1WJBAdQ==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/music-metadata/-/music-metadata-7.0.2.tgz",
+      "integrity": "sha512-NJ+iRJnX9SqER4ZkW6JFqYDThZv/ZWxpkSkrX/51Hs9Tb42Be3pPswvVRREPGiZAVYpg0BgAnijeqU3XYOTEmA==",
       "requires": {
         "content-type": "^1.0.4",
         "debug": "^4.1.0",
-        "file-type": "^14.6.2",
+        "file-type": "^14.7.1",
         "media-typer": "^1.1.0",
-        "strtok3": "^6.0.3",
+        "strtok3": "^6.0.4",
         "token-types": "^2.0.0"
       },
       "dependencies": {
@@ -8368,24 +8368,13 @@
       }
     },
     "strtok3": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.0.3.tgz",
-      "integrity": "sha512-/3RaYN9rW5WEYNHSvn081CgL4HziT027hfi5tsksbPfeWxi3BSLb8tolZDzpYU3I78/0ZqRiFpMDAqN2t4YShA==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.0.4.tgz",
+      "integrity": "sha512-rqWMKwsbN9APU47bQTMEYTPcwdpKDtmf1jVhHzNW2cL1WqAxaM9iBb9t5P2fj+RV2YsErUWgQzHD5JwV0uCTEQ==",
       "requires": {
         "@tokenizer/token": "^0.1.1",
         "@types/debug": "^4.1.5",
-        "debug": "^4.1.1",
         "peek-readable": "^3.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        }
       }
     },
     "sumchecker": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "languagedetect": "^2.0.0",
     "location-history": "^1.1.2",
     "material-ui": "^0.20.2",
-    "music-metadata": "^7.0.0",
+    "music-metadata": "^7.0.2",
     "network-address": "^1.1.2",
     "parse-torrent": "^7.1.3",
     "prettier-bytes": "^1.0.4",


### PR DESCRIPTION
Update dependency [music-metadata](https://github.com/Borewit/music-metadata) to [version v7.0.2](https://github.com/Borewit/music-metadata/releases/tag/v7.0.2) fixing a possible exception thrown while parsing WAV file. 
