### PR TITLE
Fix linux .desktop file

### DIFF
--- a/static/linux/webtorrent-desktop.ejs
+++ b/static/linux/webtorrent-desktop.ejs
@@ -11,7 +11,7 @@ Actions=CreateNewTorrent;OpenTorrentFile;OpenTorrentAddress;
 <% if (mimeType && mimeType.length) { %>MimeType=<%= mimeType.join(';') %>;<% } %>
 <% if (categories && categories.length) { %>Categories=<%= categories.join(';') %>;<% } %>
 StartupNotify=true
-<% if (name) { %>StartupWMClass=<%= name %> <% } %>
+StartupWMClass=<%= productName %>
 
 [Desktop Action CreateNewTorrent]
 Name=Create New Torrent...

--- a/static/linux/webtorrent-desktop.ejs
+++ b/static/linux/webtorrent-desktop.ejs
@@ -1,6 +1,5 @@
 [Desktop Entry]
 Type=Application
-<% if (version) { %>Version=<%= version %><% } %>
 Name=<%= productName %>
 <% if (genericName) { %>GenericName=<%= genericName %><% } %>
 <% if (description) { %>Comment=<%= description %><% } %>


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request?**

Bug fix


**What changes did you make? (Give an overview)**

WM_CLASS of the application is `webtorrent` or `WebTorrent`:
```bash
$ xprop WM_CLASS
WM_CLASS(STRING) = "webtorrent", "WebTorrent"
```

But in .desktop file is set `webtorrent-desktop`:
```bash
$ cat webtorrent-desktop.desktop | grep WM
StartupWMClass=webtorrent-desktop
```

This causes the desktop environment to not correctly connect the running instance of the application with a desktop file. This leads to not using system icon theme for the icon of running application.

**Now:**
![Snímek obrazovky pořízený 2020-08-29 13-59-50](https://user-images.githubusercontent.com/17854950/91636420-9fcaf780-ea00-11ea-9477-42eb04ba0363.png)
**Expected:**
![Snímek z 2020-08-29 16-10-03](https://user-images.githubusercontent.com/17854950/91638782-23411480-ea12-11ea-89ce-6320462e7570.png)

<hr>

The `Version` entry in the .desktop file is currently set to the application version:
```bash
cat webtorrent-desktop.desktop | grep Ver
Version=0.24.0
```

But according to the [specifications](https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#recognized-keys), it should refer to the "Version of the Desktop Entry Specification" and this field is not required.

This causes a warning during installation with Portage on Gentoo system:
```
* QA Notice: This package installs one or more .desktop files that do not
* pass validation.
* 
*   /usr/share/applications/webtorrent-desktop.desktop: error: value "0.24.0" for key "Version" in group "Desktop Entry" is not a known version
*
```