### PR TITLE
Disable background throttling

### DIFF
--- a/src/main/windows/about.js
+++ b/src/main/windows/about.js
@@ -27,7 +27,8 @@ function init () {
     webPreferences: {
       nodeIntegration: true,
       enableBlinkFeatures: 'AudioVideoTracks',
-      enableRemoteModule: true
+      enableRemoteModule: true,
+      backgroundThrottling: false
     },
     width: 300
   })

--- a/src/main/windows/main.js
+++ b/src/main/windows/main.js
@@ -45,7 +45,8 @@ function init (state, options) {
     webPreferences: {
       nodeIntegration: true,
       enableBlinkFeatures: 'AudioVideoTracks',
-      enableRemoteModule: true
+      enableRemoteModule: true,
+      backgroundThrottling: false
     },
     x: initialBounds.x,
     y: initialBounds.y

--- a/src/main/windows/webtorrent.js
+++ b/src/main/windows/webtorrent.js
@@ -27,7 +27,8 @@ function init () {
     webPreferences: {
       nodeIntegration: true,
       enableBlinkFeatures: 'AudioVideoTracks',
-      enableRemoteModule: true
+      enableRemoteModule: true,
+      backgroundThrottling: false
     },
     width: 150
   })


### PR DESCRIPTION
Reference: https://github.com/webtorrent/webtorrent-desktop/pull/1720#issuecomment-722011487

I actually think we want backgroundThrottling: false so our timers and intervals aren't throttled when the app is backgrounded.

<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

Disable background throttling. See https://www.electronjs.org/docs/api/browser-window

**Which issue (if any) does this pull request address?**

None

**Is there anything you'd like reviewers to focus on?**
