### PR TITLE
Add armv7l arch support

### DIFF
--- a/bin/package.js
+++ b/bin/package.js
@@ -172,8 +172,8 @@ const linux = {
   // Build for Linux.
   platform: 'linux',
 
-  // Build x64 and arm64 binaries.
-  arch: ['x64', 'arm64']
+  // Build x64, armv7l, and arm64 binaries.
+  arch: ['x64', 'armv7l', 'arm64']
 
   // Note: Application icon for Linux is specified via the BrowserWindow `icon` option.
 }


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix
[x] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
Add `armv7l` arch support.

Given that `electron-packager` can build for `armv7l` it is just as easy as enabling it to support devices like `Raspberry Pi 3`
 and `Raspberry Pi 4` when running in a 32bit mode 😉

**Which issue (if any) does this pull request address?**
https://github.com/webtorrent/webtorrent-desktop/issues/1857

**Is there anything you'd like reviewers to focus on?**
