### PR TITLE
Update music-metadata to version 7.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7625,13 +7625,13 @@
       }
     },
     "music-metadata": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/music-metadata/-/music-metadata-7.5.0.tgz",
-      "integrity": "sha512-PLem0psHyfYfDuZ3ir7EMXsOtkJsCgQNG0e9wvjgYeeAG2WPpwSZkPaTmuJUUIX7hxojj8VhG+iwuz/f+BpXgQ==",
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/music-metadata/-/music-metadata-7.5.1.tgz",
+      "integrity": "sha512-rkYf+LmlAaKMHSrXxxUbj53jQsCER+5MhoiqFDvsJ2aQ3jOyNbH0HqUoSc9ipYdSBCx27hAXaA/VCUfM+J8v/g==",
       "requires": {
         "content-type": "^1.0.4",
-        "debug": "^4.2.0",
-        "file-type": "^16.0.0",
+        "debug": "^4.3.1",
+        "file-type": "^16.0.1",
         "media-typer": "^1.1.0",
         "strtok3": "^6.0.4",
         "token-types": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "languagedetect": "^2.0.0",
     "location-history": "^1.1.2",
     "material-ui": "^0.20.2",
-    "music-metadata": "^7.5.0",
+    "music-metadata": "^7.5.1",
     "network-address": "^1.1.2",
     "parse-torrent": "^9.1.0",
     "prettier-bytes": "^1.0.4",


### PR DESCRIPTION
Update [music-metadata](https://github.com/Borewit/music-metadata) to version [7.5.1](https://github.com/Borewit/music-metadata/releases/tag/v7.5.1).

Relevant changes: 
* Fix showing wrong MP3 format in rare cases.