### PR TITLE
Fix cannot set property 'enabled' of undefined

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -81,9 +81,9 @@ function init () {
     isReady = true
     const state = results.state
 
+    menu.init()
     windows.main.init(state, { hidden })
     windows.webtorrent.init()
-    menu.init()
 
     // To keep app startup fast, some code is delayed.
     setTimeout(() => {

--- a/src/main/menu.js
+++ b/src/main/menu.js
@@ -74,7 +74,6 @@ function getMenuItem (label) {
     })
     if (menuItem) return menuItem
   }
-  
   return {}
 }
 

--- a/src/main/menu.js
+++ b/src/main/menu.js
@@ -74,6 +74,8 @@ function getMenuItem (label) {
     })
     if (menuItem) return menuItem
   }
+  
+  return {}
 }
 
 function getMenuTemplate () {


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
- Init menu before main window.
- Always return an object from `getMenuItem`.

**Which issue (if any) does this pull request address?**
#1315

**Is there anything you'd like reviewers to focus on?**
I wasn't able to reproduce the bug and I'm currently working on OSX.
I might be able to get a Windows setup later to try to reproduce and verify the fix.
It doesn't seem possible for the main window events to trigger callbacks before `onReady()` finishes executing right?
In case I'm missing something about Electron inner workings `menu.init()` is called first now.
Then we ensure `getMenuItem()` always returns an object, which will fix the current error, but we need to see if it makes menu options unusable, being that `Full Screen, Float on Top`.
The problem is that for some reason the main window fires `onWindowBlur` or `onWindowFocus`, which calls `menu.setWindowFocus()` before the menu is built or the labels doesn't match.
Maybe on some Windows versions `menu.items[i].submenu.items` is constructed differently?
If someone who was able to consistently reproduce the issue can give more details about how to reproduce or can test this change that would be awesome :)
