### PR TITLE
fix: resume torrents after deletion

### DIFF
--- a/src/renderer/controllers/torrent-list-controller.js
+++ b/src/renderer/controllers/torrent-list-controller.js
@@ -227,7 +227,7 @@ module.exports = class TorrentListController {
   }
 
   deleteAllTorrents (deleteData) {
-    // go back to list before the current playing torrent is deleted
+    // Go back to list before the current playing torrent is deleted
     if (this.state.location.url() === 'player') {
       dispatch('backToList')
     }

--- a/src/renderer/controllers/torrent-list-controller.js
+++ b/src/renderer/controllers/torrent-list-controller.js
@@ -227,6 +227,11 @@ module.exports = class TorrentListController {
   }
 
   deleteAllTorrents (deleteData) {
+    // go back to list before the current playing torrent is deleted
+    if (this.state.location.url() === 'player') {
+      dispatch('backToList')
+    }
+
     this.state.saved.torrents.forEach((summary) => deleteTorrentFile(summary, deleteData))
 
     this.state.saved.torrents = []


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

- Adds a condition to go back to the torrent list when the user clicks on any of the `Remove all torrrents` buttons while the player is open

**Which issue (if any) does this pull request address?**
Closes #1936

**Is there anything you'd like reviewers to focus on?**

- The steps to reproduce the bug are in #1936
- Basically, the user wants to delete all torrents while playing one of them. Two possible solutions are:
1. Keep the user from deleting torrents from the player screen
2. Force the user to go back to the torrent list and then delete them

This PR chooses the second option, but any feedback is welcome!
