### PR TITLE
chore: Set node 16 and npm 7 as minimum versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,8 @@
     "tape": "5.2.2"
   },
   "engines": {
-    "node": ">=4.0.0"
+    "node": "^16.0.0",
+    "npm": "^7.10.0"
   },
   "homepage": "https://webtorrent.io",
   "keywords": [


### PR DESCRIPTION
I want to bump the `package-lock.json` file to use the v2 format.