### PR TITLE
fix: Link to VLC using HTTPS

### DIFF
--- a/src/renderer/components/unsupported-media-modal.js
+++ b/src/renderer/components/unsupported-media-modal.js
@@ -36,7 +36,7 @@ module.exports = class UnsupportedMediaModal extends React.Component {
   }
 
   onInstall () {
-    shell.openExternal('http://www.videolan.org/vlc/')
+    shell.openExternal('https://www.videolan.org/vlc/')
 
     // TODO: dcposch send a dispatch rather than modifying state directly
     const state = this.props.state


### PR DESCRIPTION
May help with users who are man-in-the-middled and redirected to malicious websites.

See: https://github.com/webtorrent/webtorrent-desktop/issues/1908
