### PR TITLE
fix: remove erroneous playbackRate check

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ to be installed. For example on Mac, first install
 [XQuartz](http://www.xquartz.org/), then run:
 
 ```
-brew install wine mono
+$ brew install wine mono
 ```
 
 (Requires the [Homebrew](http://brew.sh/) package manager.)

--- a/src/renderer/lib/state.js
+++ b/src/renderer/lib/state.js
@@ -198,8 +198,7 @@ function shouldHidePlayerControls () {
     new Date().getTime() - this.playing.mouseStationarySince > 2000 &&
     !this.playing.mouseInControls &&
     !this.playing.isPaused &&
-    this.playing.location === 'local' &&
-    this.playing.playbackRate === 1
+    this.playing.location === 'local'
 }
 
 async function load (cb) {


### PR DESCRIPTION
A playback rate != 1 causes `shouldHidePlayerControls` to erroneously return `false`.

<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
Removed erroneous check in `shouldHidePlayerControls`

**Which issue (if any) does this pull request address?**
[Issue #2501](https://github.com/webtorrent/webtorrent-desktop/issues/2105)

**Is there anything you'd like reviewers to focus on?**
