### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/src/renderer/lib/cast.js
+++ b/src/renderer/lib/cast.js
@@ -144,7 +144,7 @@ function chromecastPlayer () {
           'Access-Control-Allow-Origin': '*',
           'Transfer-Encoding': 'chunked'
         })
-        res.end(Buffer.from(selectedSubtitle.buffer.substr(21), 'base64'))
+        res.end(Buffer.from(selectedSubtitle.buffer.slice(21), 'base64'))
       }).listen(0, () => {
         const port = ret.subServer.address().port
         const subtitlesUrl = 'http://' + state.server.networkAddress + ':' + port + '/'


### PR DESCRIPTION

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.

**Which issue (if any) does this pull request address?**

**Is there anything you'd like reviewers to focus on?**
