### PR TITLE
config init: unlink files before copying over

### DIFF
--- a/src/renderer/lib/state.js
+++ b/src/renderer/lib/state.js
@@ -116,9 +116,18 @@ function getDefaultPlayState () {
   }
 }
 
+function overwriteSync(fromPath, toPath) {
+  const { unlinkSync, copyFileSync } = require('fs')
+  try {
+    // if a previous startup failed, the file could still be write protected
+    unlinkSync(toPath)
+  } catch { }
+  copyFileSync(fromPath, toPath)
+}
+
 /* If the saved state file doesn't exist yet, here's what we use instead */
 function setupStateSaved () {
-  const { copyFileSync, mkdirSync, readFileSync } = require('fs')
+  const { mkdirSync, readFileSync } = require('fs')
   const parseTorrent = require('parse-torrent')
 
   const saved = {
@@ -146,11 +155,11 @@ function setupStateSaved () {
   config.DEFAULT_TORRENTS.forEach((t, i) => {
     const infoHash = saved.torrents[i].infoHash
     // TODO: Doing several sync calls during first startup is not ideal
-    copyFileSync(
+    overwriteSync(
       path.join(config.STATIC_PATH, t.posterFileName),
       path.join(config.POSTER_PATH, infoHash + path.extname(t.posterFileName))
     )
-    copyFileSync(
+    overwriteSync(
       path.join(config.STATIC_PATH, t.torrentFileName),
       path.join(config.TORRENT_PATH, infoHash + '.torrent')
     )


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

When:
- running a webtorrent instance in an electron instance with broken mesa libs
- (does not load) closing blank window
- run in electron with correct gfx, startup crashes:

Error:
```
Missing config file: Creating new one
(node:679284) UnhandledPromiseRejectionWarning: Error: EACCES: permission denied, copyfile '/home/user/code/webtorrent-desktop/static/bigBuckBunny.jpg' -> '/home/user/.config/WebTorrent/Posters/88594aaacbde40ef3e2510c47374ec0aa396c08e.jpg'
    at copyFileSync (node:fs:2894:3)
    at func (node:electron/js2c/asar_bundle:2:2131)
    at overwriteSync (/home/user/code/webtorrent-desktop/src/renderer/lib/state.js:125:3)
    at /home/user/code/webtorrent-desktop/src/renderer/lib/state.js:158:5
    at Array.forEach (<anonymous>)
    at setupStateSaved (/home/user/code/webtorrent-desktop/src/renderer/lib/state.js:155:27)
    at EventEmitter.load (/home/user/code/webtorrent-desktop/src/renderer/lib/state.js:230:15)
```

I wish I could explain why this happens, but neither `ls` nor `lsattr` shows anything:

```sh-session
% ls -alh ~/.config/WebTorrent/Posters
Missing config file: Creating new one
(node:679284) UnhandledPromiseRejectionWarning: Error: EACCES: permission denied, copyfile '/home/user/code/webtorrent-desktop/static/bigBuckBunny.jpg' -> '/home/user/.config/WebTorrent/Posters/88594aaacbde40ef3e2510c47374ec0aa396c08e.jpg'
    at copyFileSync (node:fs:2894:3)
    at func (node:electron/js2c/asar_bundle:2:2131)
    at overwriteSync (/home/user/code/webtorrent-desktop/src/renderer/lib/state.js:125:3)
    at /home/user/code/webtorrent-desktop/src/renderer/lib/state.js:158:5
    at Array.forEach (<anonymous>)
    at setupStateSaved (/home/user/code/webtorrent-desktop/src/renderer/lib/state.js:155:27)
    at EventEmitter.load (/home/user/code/webtorrent-desktop/src/renderer/lib/state.js:230:15)
% lsattr -a ~/.config/WebTorrent/Posters
---------------------- /home/user/.config/WebTorrent/Posters/.
---------------------- /home/user/.config/WebTorrent/Posters/..
---------------------- /home/user/.config/WebTorrent/Posters/02767050e0be2fd4db9a2ad6c12416ac806ed6ed.jpg
---------------------- /home/user/.config/WebTorrent/Posters/6a02592d2bbc069628cd5ed8a54f88ee06ac0ba5.jpg
---------------------- /home/user/.config/WebTorrent/Posters/a88fda5954e89178c372716a6a78b8180ed4dad3.jpg
---------------------- /home/user/.config/WebTorrent/Posters/88594aaacbde40ef3e2510c47374ec0aa396c08e.jpg
---------------------- /home/user/.config/WebTorrent/Posters/6a9759bffd5c0af65319979fb7832189f4f3c35d.jpg
```

The workaround fixes it though.

**Which issue (if any) does this pull request address?**

**Is there anything you'd like reviewers to focus on?**
