### PR TITLE
build macOS releases for Apple Silicon

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -39,9 +39,15 @@ jobs:
           ${{ runner.os }}-node-
     - run: npm install
     - run: npm run package -- darwin
+    - name: Verify macOS Apple Silicon binary
+      run: |
+        APP_BINARY="$(find dist -path '*/WebTorrent.app/Contents/MacOS/WebTorrent' -type f -print -quit)"
+        test -n "$APP_BINARY"
+        file "$APP_BINARY"
+        test "$(lipo -archs "$APP_BINARY")" = "arm64"
     - uses: actions/upload-artifact@v3
       with:
-        name: macos
+        name: macos-arm64
         path: |
           dist/*.dmg
           dist/*.zip

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -48,7 +48,18 @@
   npm run package -- darwin --sign
   ```
 
-  Move the `.zip` and `.dmg` file somewhere because the next step wipes the `dist/` folder away.
+  This creates Apple Silicon-only macOS artifacts:
+  `WebTorrent-v<version>-darwin-arm64.zip` for automatic updates and
+  `WebTorrent-v<version>-arm64.dmg` for manual installation. Verify the app binary before
+  uploading:
+
+  ```
+  lipo -archs dist/WebTorrent-darwin-arm64/WebTorrent.app/Contents/MacOS/WebTorrent
+  ```
+
+  The output must be `arm64`.
+
+  Move the `.zip` and `.dmg` files somewhere because the next step wipes the `dist/` folder away.
 
   ```
   npm run package -- linux --sign
@@ -68,7 +79,8 @@
 
   Follow the URL to a newly created Github release page. Manually upload the binaries from
   `webtorrent-desktop/dist/`. Open the previous release in another tab, and make sure that you
-  are uploading the same set of files, no more, no less.
+  are uploading the same set of files for Windows and Linux. For macOS, upload only the
+  Apple Silicon `.zip` and `.dmg` artifacts.
 
 ### 3. Test it
 
@@ -81,6 +93,9 @@
   codesigning worked and is valid.
 
 - Smoke test WebTorrent Desktop on each platform. Before a release, check that the following basic use cases work correctly:
+
+  On macOS, test on Apple Silicon without Rosetta and confirm Activity Monitor reports the app
+  kind as Apple.
 
   1. Click "Play" to stream a built-in torrent (e.g. Sintel)
     - Ensure that seeking to undownloaded region works and plays immediately.
@@ -103,7 +118,8 @@
 - Update the website
 
   Create a pull request in [webtorrent.io](https://github.com/webtorrent/webtorrent.io). Update
-  `config.js`, updating the desktop app version.
+  `config.js`, updating the desktop app version. Ensure the desktop update endpoint serves the
+  macOS zip for `platform=darwin&sysarch=arm64`.
 
   Once this PR is merged and Feross redeploys the WebTorrent website,
   hundreds of thousands of users around the world will start auto updating. **Merge with care.**

--- a/bin/package.js
+++ b/bin/package.js
@@ -117,8 +117,8 @@ const darwin = {
   // Build for Mac
   platform: 'darwin',
 
-  // Build x64 binary only.
-  arch: 'x64',
+  // Build Apple Silicon binary only.
+  arch: 'arm64',
 
   // The bundle identifier to use in the application's plist (Mac only).
   appBundleId: 'io.webtorrent.webtorrent',
@@ -329,7 +329,7 @@ function buildDarwin (cb) {
       console.log('Mac: Creating zip...')
 
       const inPath = path.join(buildPath[0], config.APP_NAME + '.app')
-      const outPath = path.join(DIST_PATH, BUILD_NAME + '-darwin.zip')
+      const outPath = path.join(DIST_PATH, BUILD_NAME + '-darwin-arm64.zip')
       zip.zipSync(inPath, outPath)
 
       console.log('Mac: Created zip.')
@@ -340,7 +340,7 @@ function buildDarwin (cb) {
 
       const appDmg = require('appdmg')
 
-      const targetPath = path.join(DIST_PATH, BUILD_NAME + '.dmg')
+      const targetPath = path.join(DIST_PATH, BUILD_NAME + '-arm64.dmg')
       rimraf.sync(targetPath)
 
       // Create a .dmg (Mac disk image) file, for easy user installation.
@@ -615,7 +615,10 @@ function buildLinux (cb) {
 }
 
 function printDone (err) {
-  if (err) console.error(err.message || err)
+  if (err) {
+    console.error(err.message || err)
+    process.exitCode = 1
+  }
 }
 
 /*

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@electron/remote": "2.1.3",
         "airplayer": "github:webtorrent/airplayer#fix-security",
         "application-config": "2.0.0",
-        "arch": "2.2.0",
         "auto-launch": "5.0.5",
         "bitfield": "4.1.0",
         "capture-frame": "4.0.0",
@@ -17442,11 +17441,6 @@
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
       "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
       "dev": true
-    },
-    "arch": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/arch/-/arch-2.2.0.tgz",
-      "integrity": "sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ=="
     },
     "archiver": {
       "version": "5.1.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "@electron/remote": "2.1.3",
     "airplayer": "github:webtorrent/airplayer#fix-security",
     "application-config": "2.0.0",
-    "arch": "2.2.0",
     "auto-launch": "5.0.5",
     "bitfield": "4.1.0",
     "capture-frame": "4.0.0",

--- a/src/config.js
+++ b/src/config.js
@@ -1,7 +1,7 @@
 const appConfig = require('application-config')('WebTorrent')
+const os = require('os')
 const path = require('path')
 const { app } = require('electron')
-const arch = require('arch')
 
 const APP_NAME = 'WebTorrent'
 const APP_TEAM = 'WebTorrent, LLC'
@@ -82,7 +82,7 @@ module.exports = {
   IS_PRODUCTION,
   IS_TEST,
 
-  OS_SYSARCH: arch() === 'x64' ? 'x64' : 'ia32',
+  OS_SYSARCH: getSystemArch(),
 
   POSTER_PATH: path.join(getConfigPath(), 'Posters'),
   ROOT_PATH: path.join(__dirname, '..'),
@@ -131,6 +131,12 @@ function getPath (key) {
     // Electron main process
     return app.getPath(key)
   }
+}
+
+function getSystemArch () {
+  const systemArch = os.arch()
+  if (systemArch === 'arm64' || systemArch === 'x64') return systemArch
+  return 'ia32'
 }
 
 function isTest () {


### PR DESCRIPTION
## Summary

This switches the macOS release path from Intel x64 to Apple Silicon arm64.

Changes:
- Build macOS Electron packages with `darwin arm64`
- Rename macOS artifacts to include `arm64`
- Report `OS_SYSARCH=arm64` so the update feed can serve architecture-specific releases
- Remove the now-unused `arch` dependency
- Add a package workflow gate that verifies the packaged app binary with `lipo -archs`
- Update release docs for Apple Silicon artifacts and update feed requirements

Implemented collaboratively with Codex.

## Verification

- `npm test`
- `npm run build`
- `npm run package -- darwin --package zip`
- `lipo -archs dist/WebTorrent-darwin-arm64/WebTorrent.app/Contents/MacOS/WebTorrent` outputs `arm64`
- Confirmed `dist/WebTorrent-v0.24.0-darwin-arm64.zip` is produced
- Confirmed `src/config.js` reports `OS_SYSARCH=arm64` on Apple Silicon

## Notes

`npm run test-integration` currently fails locally with Spectron `Application not running`, including under Node 18. This appears unrelated to the packaging change and looks like a local GUI/Spectron environment issue.

The website/update endpoint should also be updated so `platform=darwin&sysarch=arm64` serves the macOS arm64 zip.